### PR TITLE
Fixed leaks in get_trema_{pid,name}().

### DIFF
--- a/src/lib/trema.c
+++ b/src/lib/trema.c
@@ -273,6 +273,8 @@ static bool run_as_daemon = false;
 static char *trema_name = NULL;
 static char *executable_name = NULL;
 static char *trema_log = NULL;
+static char *trema_pid = NULL;
+static char *trema_sock = NULL;
 static pthread_mutex_t mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 
@@ -319,17 +321,23 @@ get_trema_log() {
 
 static const char *
 get_trema_pid() {
-  char path[ PATH_MAX ];
-  sprintf( path, "%s/pid", get_trema_tmp() );
-  return xstrdup( path );
+  if ( trema_pid == NULL ) {
+    char path[ PATH_MAX ];
+    sprintf( path, "%s/pid", get_trema_tmp() );
+    trema_pid = xstrdup( path );
+  }
+  return trema_pid;
 }
 
 
 static const char *
 get_trema_sock() {
-  char path[ PATH_MAX ];
-  sprintf( path, "%s/sock", get_trema_tmp() );
-  return xstrdup( path );
+  if ( trema_sock == NULL ) {
+    char path[ PATH_MAX ];
+    sprintf( path, "%s/sock", get_trema_tmp() );
+    trema_sock = xstrdup( path );
+  }
+  return trema_sock;
 }
 
 


### PR DESCRIPTION
The get_trema_pid() and get_trema_name() functions leak the return strings, causing valgrind to complain.

Fixed to use global variables to store the result.
