### PR TITLE
Improved error message when log file cannot be created.

### DIFF
--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -130,8 +130,11 @@ open_log( const char *ident, const char *log_directory ) {
   char pathname[ PATH_MAX ];
   sprintf( pathname, "%s/%s.log", log_directory, ident );
   FILE *log = fopen( pathname, "w" );
+
   if ( log == NULL ) {
-    perror( "fopen" );
+    char error_msg[ PATH_MAX + 32 ];
+    snprintf( error_msg, PATH_MAX + 32, "open_log: fopen( \"%s\", \"w\" )", pathname );
+    perror( error_msg );
     trema_abort();
   }
 


### PR DESCRIPTION
When the log file cannot be opened switch manager only prints the error string, with no indication of what it was that failed to open.

This patch gives more information, including the pathname.
