### PR TITLE
Properly return the ruby number type when calling arp oper.

### DIFF
--- a/ruby/trema/packet_in.c
+++ b/ruby/trema/packet_in.c
@@ -236,7 +236,7 @@ packet_in_is_arp( VALUE self ) {
  */
 static VALUE
 packet_in_arp_oper( VALUE self ) {
-  return get_packet_in_info( self )->arp_ar_op;
+  return UINT2NUM( ( unsigned int ) get_packet_in_info( self )->arp_ar_op );
 }
 
 


### PR DESCRIPTION
The arp_oper methods was returning the integer value instead of converting to a ruby number type.
