### PR TITLE
fix renaming error packet_in.rb changed to packet-in.rb

### DIFF
--- a/features/tutorial.packet_in.feature
+++ b/features/tutorial.packet_in.feature
@@ -27,7 +27,7 @@ Feature: Tutorial: Handling packet_in events example
 
 
   Scenario: Handle packet_in in Ruby
-    When I try trema run "./src/examples/packet_in/packet_in.rb" with following configuration (backgrounded):
+    When I try trema run "./src/examples/packet_in/packet-in.rb" with following configuration (backgrounded):
       """
       vswitch("packet_in") { dpid "0xabc" }
 


### PR DESCRIPTION
Takamiya-san

Fix renaming error in tutorial.packet_in.feature file.

Kind regards

Nick
