### PR TITLE
Added unix listening socket support to switch manager

### DIFF
--- a/features/switch_manager.feature
+++ b/features/switch_manager.feature
@@ -14,6 +14,7 @@ Feature: switch_manager help
         -s, --switch=PATH           the command path of switch
         -n, --name=SERVICE_NAME     service name
         -p, --port=PORT             server listen port (default 6633)
+        -u, --unix=PATH             server listen unix socket
         -d, --daemonize             run in the background
         -l, --logging_level=LEVEL   set logging level
         -h, --help                  display this help and exit
@@ -29,6 +30,7 @@ Feature: switch_manager help
         -s, --switch=PATH           the command path of switch
         -n, --name=SERVICE_NAME     service name
         -p, --port=PORT             server listen port (default 6633)
+        -u, --unix=PATH             server listen unix socket
         -d, --daemonize             run in the background
         -l, --logging_level=LEVEL   set logging level
         -h, --help                  display this help and exit

--- a/ruby/trema/dsl/configuration.rb
+++ b/ruby/trema/dsl/configuration.rb
@@ -43,6 +43,16 @@ module Trema
       attr_accessor :port
 
       #
+      # set/get the unix socket for switch manager to listen on
+      #
+      # @example
+      #   config.unix_path = '/foo/bar.socket'
+      #
+      # @return [String]
+      #
+      attr_accessor :unix_path
+
+      #
       # use tremashark?
       #
       # @example

--- a/ruby/trema/dsl/runner.rb
+++ b/ruby/trema/dsl/runner.rb
@@ -67,7 +67,7 @@ module Trema
               # two or more apps without switch_manager.
               raise "No event routing configured. Use `event' directive to specify event routing."
             end
-            SwitchManager.new( rule, @context.port )
+            SwitchManager.new( rule, @context.port, @context.unix_path )
           end
         switch_manager.run!
       end

--- a/ruby/trema/switch-manager.rb
+++ b/ruby/trema/switch-manager.rb
@@ -67,9 +67,10 @@ module Trema
     #
     # @return [SwitchManager]
     #
-    def initialize rule, port = nil
+    def initialize rule, port = nil, unix_path = nil
       @rule = rule
       @port = port
+      @unix_path = unix_path
       @no_flow_cleanup = false
       SwitchManager.add self
     end
@@ -100,7 +101,13 @@ module Trema
 
     def options
       opts = [ "--daemonize" ]
-      opts << "--port=#{ @port }" if @port
+
+      if @unix_path
+        opts << "--unix=#{ @unix_path }"
+      elsif @port
+        opts << "--port=#{ @port }"
+      end
+
       opts
     end
 

--- a/spec/trema/dsl/runner_spec.rb
+++ b/spec/trema/dsl/runner_spec.rb
@@ -48,7 +48,8 @@ module Trema
             :hosts => {},
             :switches => {},
             :apps => {},
-            :port => 6633
+            :port => 6633,
+            :unix_path => nil
           )
 
           Runner.new( context ).run
@@ -61,6 +62,7 @@ module Trema
           context = mock(
             "context",
             :port => 6633,
+            :unix_path => nil,
             :tremashark => nil,
             :switch_manager => nil,
             :packetin_filter => nil,
@@ -87,7 +89,8 @@ module Trema
             :hosts => {},
             :switches => {},
             :apps => {},
-            :port => 6633
+            :port => 6633,
+            :unix_path => nil
           )
 
           Runner.new( context ).run
@@ -116,7 +119,8 @@ module Trema
             :hosts => {},
             :switches => {},
             :apps => {},
-            :port => 6633
+            :port => 6633,
+            :unix_path => nil
           )
 
           Runner.new( context ).run
@@ -158,7 +162,8 @@ module Trema
             :hosts => { "host0" => host0, "host1" => host1, "host2" => host2 },
             :switches => {},
             :apps => {},
-            :port => 6633
+            :port => 6633,
+            :unix_path => nil
           )
 
           Runner.new( context ).run
@@ -184,7 +189,8 @@ module Trema
             :hosts => {},
             :switches => { "switch0" => switch0, "switch1" => switch1, "switch 2" => switch2 },
             :apps => {},
-            :port => 6633
+            :port => 6633,
+            :unix_path => nil
           )
 
           Runner.new( context ).run

--- a/src/switch_manager/secure_channel_listener.h
+++ b/src/switch_manager/secure_channel_listener.h
@@ -27,7 +27,8 @@
 #include "switch_manager.h"
 
 
-bool secure_channel_listen_start( struct listener_info *listener_info );
+bool secure_channel_listen_inet( struct listener_info *listener_info );
+bool secure_channel_listen_unix( struct listener_info *listener_info );
 void secure_channel_accept( int fd, void *data );
 
 

--- a/src/switch_manager/switch_manager.c
+++ b/src/switch_manager/switch_manager.c
@@ -147,6 +147,7 @@ struct listener_info listener_info;
 static struct option long_options[] = {
   { "port", 1, NULL, 'p' },
   { "switch", 1, NULL, 's' },
+  { "unix", 1, NULL, 'u' },
   { NULL, 0, NULL, 0  },
 };
 
@@ -156,17 +157,18 @@ static char short_options[] = "p:s:";
 void
 usage() {
   printf(
-	 "OpenFlow Switch Manager.\n"
-	 "Usage: %s [OPTION]... [-- SWITCH_MANAGER_OPTION]...\n"
-	 "\n"
-	 "  -s, --switch=PATH           the command path of switch\n"
-	 "  -n, --name=SERVICE_NAME     service name\n"
+         "OpenFlow Switch Manager.\n"
+         "Usage: %s [OPTION]... [-- SWITCH_MANAGER_OPTION]...\n"
+         "\n"
+         "  -s, --switch=PATH           the command path of switch\n"
+         "  -n, --name=SERVICE_NAME     service name\n"
          "  -p, --port=PORT             server listen port (default %u)\n"
-	 "  -d, --daemonize             run in the background\n"
-	 "  -l, --logging_level=LEVEL   set logging level\n"
-	 "  -h, --help                  display this help and exit\n"
-	 , get_executable_name(), OFP_TCP_PORT
-	 );
+         "  -u, --unix=PATH             server listen unix socket\n"
+         "  -d, --daemonize             run in the background\n"
+         "  -l, --logging_level=LEVEL   set logging level\n"
+         "  -h, --help                  display this help and exit\n"
+         , get_executable_name(), OFP_TCP_PORT
+         );
 }
 
 
@@ -251,8 +253,10 @@ static void
 init_listener_info( struct listener_info *listener_info ) {
   memset( listener_info, 0, sizeof( struct listener_info ) );
   listener_info->switch_daemon = xconcatenate_path( get_trema_home(), SWITCH_MANAGER_PATH );
-  listener_info->listen_port = OFP_TCP_PORT;
   listener_info->listen_fd = -1;
+  listener_info->listen_type = LISTENER_INFO_DEFAULT;
+  listener_info->listen_port = OFP_TCP_PORT;
+  listener_info->listen_path = NULL;
 }
 
 
@@ -268,6 +272,10 @@ finalize_listener_info(  struct listener_info *listener_info ) {
 
     close( listener_info->listen_fd );
     listener_info->listen_fd = -1;
+  }
+  if ( listener_info->listen_path != NULL ) {
+    xfree( listener_info->listen_path );
+    listener_info->listen_path = NULL;
   }
 }
 
@@ -293,10 +301,24 @@ parse_argument( struct listener_info *listener_info, int argc, char *argv[] ) {
   while ( ( c = getopt_long( argc, argv, short_options, long_options, NULL ) ) != -1 ) {
     switch ( c ) {
       case 'p':
+        if ( listener_info->listen_type != LISTENER_INFO_DEFAULT ) {
+          return false;
+        }
+
+        listener_info->listen_type = LISTENER_INFO_INET;
         listener_info->listen_port = strtoport( optarg );
+
         if ( listener_info->listen_port == 0 ) {
           return false;
         }
+        break;
+      case 'u':
+        if ( listener_info->listen_type != LISTENER_INFO_DEFAULT ) {
+          return false;
+        }
+
+        listener_info->listen_type = LISTENER_INFO_UNIX;
+        listener_info->listen_path = xstrdup( optarg );
         break;
       case 's':
         xfree( (void *)( uintptr_t )listener_info->switch_daemon );
@@ -420,7 +442,21 @@ main( int argc, char *argv[] ) {
   catch_sigchild();
 
   // listener start (listen socket binding and listen)
-  ret = secure_channel_listen_start( &listener_info );
+  switch ( listener_info.listen_type ) {
+  case LISTENER_INFO_DEFAULT:
+  case LISTENER_INFO_INET:
+    debug( "Opening inet listening socket ( port=%u ).", ( unsigned int )listener_info.listen_port );
+    ret = secure_channel_listen_inet( &listener_info );
+    break;
+  case LISTENER_INFO_UNIX:
+    debug( "Opening unix listening socket ( path=%s ).", listener_info.listen_path );
+    ret = secure_channel_listen_unix( &listener_info );
+    break;
+  default:
+    debug( "Unknown listener socket protocol type." );
+    ret = 0;
+  }
+
   if ( !ret ) {
     finalize_listener_info( &listener_info );
     exit( EXIT_FAILURE );

--- a/src/switch_manager/switch_manager.h
+++ b/src/switch_manager/switch_manager.h
@@ -42,13 +42,21 @@ static const uint SWITCH_MANAGER_ADDR_STR_LEN = sizeof( "255.255.255.255:65535" 
 static const char SWITCH_MANAGER_PATH[] = "objects/switch_manager/switch";
 static const char SWITCH_MANAGER_STATE_PREFIX[] = "state_notify::";
 
+enum {
+  LISTENER_INFO_DEFAULT,
+  LISTENER_INFO_INET,
+  LISTENER_INFO_UNIX
+};
 
 struct listener_info {
   const char *switch_daemon;
   int switch_daemon_argc;
   char **switch_daemon_argv;
-  uint16_t listen_port;
+
+  int listen_type;
   int listen_fd;
+  uint16_t listen_port;
+  char *listen_path;
 };
 
 


### PR DESCRIPTION
OVS has for some time had support for unix sockets in order to avoid issues with in-band packet handling. This patch adds a '--unix=/foo/bar.socket' option to switch manager for listening on unix sockets.

All unit tests run, however there are no tests for this specific feature currently in place.
