### PR TITLE
fixes yard errors for all action subclasses.

### DIFF
--- a/ruby/trema/action-common.c
+++ b/ruby/trema/action-common.c
@@ -50,6 +50,12 @@ dl_addr_to_a( VALUE dl_addr, uint8_t *ret_dl_addr ) {
 }
 
 
+VALUE
+action_base_class( void ) {
+  return rb_path2class( "Trema::Action" );
+}
+
+
 /*
  * Local variables:
  * c-basic-offset: 2

--- a/ruby/trema/action-common.h
+++ b/ruby/trema/action-common.h
@@ -23,6 +23,7 @@
 uint32_t nw_addr_to_i( VALUE nw_addr );
 VALUE nw_addr_to_s( VALUE nw_addr );
 uint8_t *dl_addr_to_a( VALUE dl_addr, uint8_t *ret_dl_addr );
+VALUE action_base_class( void );
 
 
 #endif // ACTION_COMMON_H

--- a/ruby/trema/action-enqueue.c
+++ b/ruby/trema/action-enqueue.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -159,7 +160,8 @@ action_enqueue_inspect( VALUE self ) {
 void
 Init_action_enqueue() {
   rb_require( "trema/action" );
-  cActionEnqueue = rb_define_class_under( mTrema, "ActionEnqueue", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionEnqueue = rb_define_class_under( mTrema, "ActionEnqueue", rb_cAction );
   rb_define_method( cActionEnqueue, "initialize", action_enqueue_init, -1 );
   rb_define_method( cActionEnqueue, "append", action_enqueue_append, 1 );
   rb_define_method( cActionEnqueue, "inspect", action_enqueue_inspect, 0 );

--- a/ruby/trema/action-output.c
+++ b/ruby/trema/action-output.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -161,7 +162,8 @@ action_output_inspect( VALUE self ) {
 void
 Init_action_output() {
   rb_require( "trema/action" );
-  cActionOutput = rb_define_class_under( mTrema, "ActionOutput", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionOutput = rb_define_class_under( mTrema, "ActionOutput", rb_cAction );
   rb_define_method( cActionOutput, "initialize", action_output_init, 1 );
   rb_define_method( cActionOutput, "append", action_output_append, 1 );
   rb_define_method( cActionOutput, "inspect", action_output_inspect, 0 );

--- a/ruby/trema/action-set-dl-dst.c
+++ b/ruby/trema/action-set-dl-dst.c
@@ -118,7 +118,8 @@ action_set_dl_dst_inspect( VALUE self ) {
 void
 Init_action_set_dl_dst() {
   rb_require( "trema/action" );
-  cActionSetDlDst = rb_define_class_under( mTrema, "ActionSetDlDst", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionSetDlDst = rb_define_class_under( mTrema, "ActionSetDlDst", rb_cAction );
   rb_define_method( cActionSetDlDst, "initialize", action_set_dl_dst_init, -1 );
   rb_define_method( cActionSetDlDst, "append", action_set_dl_dst_append, 1 );
   rb_define_method( cActionSetDlDst, "inspect", action_set_dl_dst_inspect, 0 );

--- a/ruby/trema/action-set-dl-src.c
+++ b/ruby/trema/action-set-dl-src.c
@@ -71,8 +71,8 @@ void
 Init_action_set_dl_src() {
   rb_require( "trema/action" );
   rb_require( "trema/mac" );
-  VALUE action_base_class = rb_path2class( "Trema::Action" );
-  cActionSetDlSrc = rb_define_class_under( mTrema, "ActionSetDlSrc", action_base_class );
+  VALUE rb_cAction = action_base_class();
+  cActionSetDlSrc = rb_define_class_under( mTrema, "ActionSetDlSrc", rb_cAction );
   rb_define_method( cActionSetDlSrc, "initialize", action_set_dl_src_init, 1 );
   rb_define_method( cActionSetDlSrc, "append", action_set_dl_src_append, 1 );
 }

--- a/ruby/trema/action-set-nw-dst.c
+++ b/ruby/trema/action-set-nw-dst.c
@@ -123,7 +123,8 @@ void
 Init_action_set_nw_dst() {
   rb_require( "trema/ip" );
   rb_require( "trema/action" );
-  cActionSetNwDst = rb_define_class_under( mTrema, "ActionSetNwDst", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionSetNwDst = rb_define_class_under( mTrema, "ActionSetNwDst", rb_cAction );
   rb_define_method( cActionSetNwDst, "initialize", action_set_nw_dst_init, -1 );
   rb_define_method( cActionSetNwDst, "append", action_set_nw_dst_append, 1 );
   rb_define_method( cActionSetNwDst, "inspect", action_set_nw_dst_inspect, 0 );

--- a/ruby/trema/action-set-nw-src.c
+++ b/ruby/trema/action-set-nw-src.c
@@ -128,7 +128,8 @@ void
 Init_action_set_nw_src() {
   rb_require( "ipaddr" );
   rb_require( "trema/action" );
-  cActionSetNwSrc = rb_define_class_under( mTrema, "ActionSetNwSrc", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionSetNwSrc = rb_define_class_under( mTrema, "ActionSetNwSrc", rb_cAction );
   rb_define_method( cActionSetNwSrc, "initialize", action_set_nw_src_init, -1 );
   rb_define_method( cActionSetNwSrc, "append", action_set_nw_src_append, 1 );
   rb_define_method( cActionSetNwSrc, "inspect", action_set_nw_src_inspect, 0 );

--- a/ruby/trema/action-set-nw-tos.c
+++ b/ruby/trema/action-set-nw-tos.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -113,7 +114,8 @@ action_set_nw_tos_inspect( VALUE self ) {
 void
 Init_action_set_nw_tos() {
   rb_require( "trema/action" );
-  cActionSetNwTos = rb_define_class_under( mTrema, "ActionSetNwTos", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionSetNwTos = rb_define_class_under( mTrema, "ActionSetNwTos", rb_cAction );
   rb_define_method( cActionSetNwTos, "initialize", action_set_nw_tos_init, -1 );
   rb_define_method( cActionSetNwTos, "append", action_set_nw_tos_append, 1 );
   rb_define_method( cActionSetNwTos, "inspect", action_set_nw_tos_inspect, 0 );

--- a/ruby/trema/action-set-tp-dst.c
+++ b/ruby/trema/action-set-tp-dst.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -111,7 +112,8 @@ action_set_tp_dst_inspect( VALUE self ) {
 void
 Init_action_set_tp_dst() {
   rb_require( "trema/action" );
-  cActionSetTpDst = rb_define_class_under( mTrema, "ActionSetTpDst", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionSetTpDst = rb_define_class_under( mTrema, "ActionSetTpDst", rb_cAction );
   rb_define_method( cActionSetTpDst, "initialize", action_set_tp_dst_init, -1 );
   rb_define_method( cActionSetTpDst, "append", action_set_tp_dst_append, 1 );
   rb_define_method( cActionSetTpDst, "inspect", action_set_tp_dst_inspect, 0 );

--- a/ruby/trema/action-set-tp-src.c
+++ b/ruby/trema/action-set-tp-src.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -113,7 +114,8 @@ action_set_tp_src_inspect( VALUE self ) {
 void
 Init_action_set_tp_src() {
   rb_require( "trema/action" );
-  cActionSetTpSrc = rb_define_class_under( mTrema, "ActionSetTpSrc", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionSetTpSrc = rb_define_class_under( mTrema, "ActionSetTpSrc", rb_cAction );
   rb_define_method( cActionSetTpSrc, "initialize", action_set_tp_src_init, -1 );
   rb_define_method( cActionSetTpSrc, "append", action_set_tp_src_append, 1 );
   rb_define_method( cActionSetTpSrc, "inspect", action_set_tp_src_inspect, 0 );

--- a/ruby/trema/action-set-vlan-pcp.c
+++ b/ruby/trema/action-set-vlan-pcp.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -116,7 +117,8 @@ action_set_vlan_pcp_inspect( VALUE self ) {
 void
 Init_action_set_vlan_pcp() {
   rb_require( "trema/action" );
-  cActionSetVlanPcp = rb_define_class_under( mTrema, "ActionSetVlanPcp", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionSetVlanPcp = rb_define_class_under( mTrema, "ActionSetVlanPcp", rb_cAction );
   rb_define_method( cActionSetVlanPcp, "initialize", action_set_vlan_pcp_init, -1 );
   rb_define_method( cActionSetVlanPcp, "append", action_set_vlan_pcp_append, 1 );
   rb_define_method( cActionSetVlanPcp, "inspect", action_set_vlan_pcp_inspect, 0 );

--- a/ruby/trema/action-set-vlan-vid.c
+++ b/ruby/trema/action-set-vlan-vid.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -114,7 +115,8 @@ action_set_vlan_vid_inspect( VALUE self ) {
 void
 Init_action_set_vlan_vid() {
   rb_require( "trema/action" );
-  cActionSetVlanVid = rb_define_class_under( mTrema, "ActionSetVlanVid", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionSetVlanVid = rb_define_class_under( mTrema, "ActionSetVlanVid", rb_cAction );
   rb_define_method( cActionSetVlanVid, "initialize", action_set_vlan_vid_init, -1 );
   rb_define_method( cActionSetVlanVid, "append", action_set_vlan_vid_append, 1 );
   rb_define_method( cActionSetVlanVid, "inspect", action_set_vlan_vid_inspect, 0 );

--- a/ruby/trema/action-strip-vlan.c
+++ b/ruby/trema/action-strip-vlan.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -67,7 +68,8 @@ action_strip_vlan_inspect( VALUE self ) {
 void
 Init_action_strip_vlan() {
   rb_require( "trema/action" );
-  cActionStripVlan = rb_define_class_under( mTrema, "ActionStripVlan", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionStripVlan = rb_define_class_under( mTrema, "ActionStripVlan", rb_cAction );
   rb_define_method( cActionStripVlan, "initialize", action_strip_vlan_init, 0 );
   rb_define_method( cActionStripVlan, "append", action_strip_vlan_append, 1 );
   rb_define_method( cActionStripVlan, "inspect", action_strip_vlan_inspect, 0 );

--- a/ruby/trema/action-vendor.c
+++ b/ruby/trema/action-vendor.c
@@ -20,6 +20,7 @@
 
 #include "trema.h"
 #include "ruby.h"
+#include "action-common.h"
 
 
 extern VALUE mTrema;
@@ -110,7 +111,8 @@ action_vendor_inspect( VALUE self ) {
 void
 Init_action_vendor() {
   rb_require( "trema/action" );
-  cActionVendor = rb_define_class_under( mTrema, "ActionVendor", rb_path2class( "Trema::Action" ) );
+  VALUE rb_cAction = action_base_class();
+  cActionVendor = rb_define_class_under( mTrema, "ActionVendor", rb_cAction );
   rb_define_method( cActionVendor, "initialize", action_vendor_init, -1 );
   rb_define_method( cActionVendor, "append", action_vendor_append, 1 );
   rb_define_method( cActionVendor, "inspect", action_vendor_inspect, 0 );


### PR DESCRIPTION
Takamiya-san

I added the action_base_class function in action-common.c file and merged your changes as suggested.

BTW stats-request classes also don't shown either. I would investigate the problem later.

Kind regards

Nick
