### PR TITLE
simpify action nw_tos, refactoring

### DIFF
--- a/ruby/trema/action-set-nw-tos.c
+++ b/ruby/trema/action-set-nw-tos.c
@@ -57,9 +57,7 @@ action_set_nw_tos_init( VALUE self, VALUE nw_tos ) {
 
 
 /*
- * Appends its action(nw_tos) to the list of actions.
- *
- * @return [ActionSetNwTos] self
+ * @private
  */
 static VALUE
 action_set_nw_tos_append( VALUE self, VALUE action_ptr ) {

--- a/spec/trema/action-set-nw-tos_spec.rb
+++ b/spec/trema/action-set-nw-tos_spec.rb
@@ -20,7 +20,7 @@ require File.join( File.dirname( __FILE__ ), "..", "spec_helper" )
 require "trema"
 
 
-describe ActionSetNwTos, ".new(value)" do
+describe ActionSetNwTos, ".new( value )" do
   subject { ActionSetNwTos.new( value ) }
   
   context "when 32" do
@@ -30,7 +30,7 @@ describe ActionSetNwTos, ".new(value)" do
 end
 
 
-describe ActionSetNwTos, ".new(invalid_value)" do
+describe ActionSetNwTos, ".new( invalid_value )" do
   subject { ActionSetNwTos.new( invalid_value ) }
 
   context "when -1" do


### PR DESCRIPTION
Takamiya-san

I think I followed your refactoring method but I might be wrong. Anyway here is the first one action-set-nw-tos
BTW just a small correction in the file action-set-dl-dst_spec.rb.
    its ( :value ) { should == Mac.new( "52:54:00:a8:ad:8c" ) }

Remove the space after the its keyword. Also in this statement what does the should compares? Please explain to me. Because I think if we are comparing strings it would be better to use the eql instead of ==

Kind regards

Nick
