### PR TITLE
Add discover_path example

### DIFF
--- a/Rantfile
+++ b/Rantfile
@@ -64,6 +64,7 @@ task :examples => [
   "examples:switch_info",
   "examples:switch_monitor",
   "examples:traffic_monitor",
+  "examples:discover_path",
 ]
 
 
@@ -604,6 +605,7 @@ standalone_examples = [
   "switch_info",
   "switch_monitor",
   "traffic_monitor",
+  "discover_path",
 ]
 
 standalone_examples.each do | each |

--- a/src/examples/discover_path/README
+++ b/src/examples/discover_path/README
@@ -1,0 +1,18 @@
+This directory includes an OpenFlow controller that discovers all the path that are connected to a node, which means switch or host, through a physical port.
+
+# How to run
+
+Run this:
+  
+  % ./trema run ./objects/examples/discover_path/discover_path -c src/examples/discover_path/network.conf
+
+After a while, you can see a network topology dump message how the switches are connected.
+
+Then on another terminal, send a packet to inform location of host
+
+  % ./trema send_packets --source host1 --dest host2 --n_pkts 1
+
+This will cause a update of network topology infomation, and you can see a renewd one.
+In a similar way, you can update this by send_packets operation from another host, which is described at configuration file.
+
+  % ./trema send_packets --source host2 --dest host1 --n_pkts 1

--- a/src/examples/discover_path/discover_path.c
+++ b/src/examples/discover_path/discover_path.c
@@ -1,0 +1,181 @@
+/*
+ * Author: Hiroyasu OHYAMA
+ *
+ * Copyright (C) 2012 Univ. of tsukuba
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#include "trema.h"
+
+#include "discover_queue.h"
+#include "ofnode.h"
+
+#define BUFLEN ( 100 )
+
+#define DISCOVERING_INTERVAL ( 3 )
+
+static void 
+send_discover_packet( uint64_t dpid ) {
+  buffer *buf = alloc_buffer_with_length( BUFLEN );
+  buf->length = BUFLEN;
+
+  /* setting ethernet header infomation */
+  ether_header_t *l2hdr = ( ether_header_t * ) buf->data;
+  memcpy( l2hdr->macsa, ( uint8_t * ) &dpid, ETH_ADDRLEN );
+  l2hdr->type = ETH_ETHTYPE_UKNOWN;
+
+  buf->user_data = ( void * ) malloc(sizeof(uint64_t));
+  *( ( uint64_t * ) buf->user_data ) = dpid;
+
+  /* setting forwarding action */
+  openflow_actions *actions = create_actions();
+  append_action_output( actions, OFPP_FLOOD, 0 );
+
+  /* making a message of Send-Packet and send it to switch */
+  buffer *packet_out = create_packet_out( get_transaction_id(), UINT32_MAX, OFPP_NONE, actions, buf );
+  send_openflow_message( dpid, packet_out );
+  
+  free_buffer( buf );
+}
+
+static void
+send_feature_request( uint64_t dpid ) {
+  buffer *message = create_features_request( get_transaction_id() );
+  send_openflow_message( dpid, message );
+  free_buffer( message );
+}
+
+static void
+handle_switch_ready( uint64_t datapath_id, void *user_data ) {
+  UNUSED( user_data );
+
+  send_feature_request( datapath_id );
+}
+
+static void
+handle_packet_in( uint64_t datapath_id, packet_in message ) {
+  packet_info pinfo = get_packet_info( message.data );
+
+  if ( pinfo.eth_type == ETH_ETHTYPE_UKNOWN ) {
+    uint64_t from_dpid = 0;
+  
+    memcpy( ( uint8_t * ) &from_dpid, pinfo.eth_macsa, ETH_ADDRLEN );
+  
+    discover_queue_push_switch( datapath_id, from_dpid, message.in_port );
+  } else {
+    ofnode_create_host( pinfo.eth_macsa, pinfo.ipv4_saddr );
+
+    discover_queue_push_host( datapath_id, pinfo.eth_macsa, pinfo.ipv4_saddr, message.in_port );
+  }
+}
+
+static void
+handle_features_reply (
+  uint64_t datapath_id,
+  uint32_t transaction_id,
+  uint32_t n_buffers,
+  uint8_t n_tables,
+  uint32_t capabilities,
+  uint32_t actions,
+  const list_element *phy_ports,
+  void *user_data
+) {
+  UNUSED( transaction_id );
+  UNUSED( n_buffers );
+  UNUSED( n_tables );
+  UNUSED( capabilities );
+  UNUSED( actions );
+  UNUSED( user_data );
+
+  uint16_t port_len = ( uint16_t ) list_length_of( phy_ports );
+  
+  ofnode_create_switch( datapath_id, port_len );
+
+  send_discover_packet( datapath_id );
+}
+
+static void 
+discover_path( void *data ) {
+  UNUSED( data );
+
+  bool is_update = false;
+  discover_queue_entry *queue_entry;
+
+  do {
+    queue_entry = discover_queue_pop();
+
+    if ( queue_entry != NULL ) {
+      struct ofnode *target_node;
+      struct ofnode *from_node = NULL;
+      int in_port = queue_entry->in_port;
+
+      /* The case of receving discovery packet before 
+       * receving features reply. */
+      target_node = ofnode_get_switch( queue_entry->target_dpid );
+      if ( target_node == NULL ) {
+        discover_queue_push( queue_entry );
+        break;
+      }
+  
+      if ( queue_entry->type == TYPE_SWITCH ) {
+        /* append a switch infomation to target ofnode */
+
+        /* The case of receving discovery packet before 
+         * receving features reply. */
+        from_node = ofnode_get_switch( queue_entry->from_dpid );
+        if ( from_node == NULL ) {
+          discover_queue_push( queue_entry );
+          break;
+        }
+
+      } else if ( queue_entry->type == TYPE_HOST ) {
+        /* append a host infomation to target ofnode */
+        from_node = ofnode_get_host( queue_entry->nw_addr );
+      }
+  
+      target_node->switch_info.ports[ in_port ] = from_node;
+  
+      is_update = true;
+  
+      xfree( queue_entry );
+    } else if ( is_update ) {
+      is_update = false;
+  
+      ofnode_show_table();
+    }
+  } while ( queue_entry != NULL );
+}
+
+int
+main( int argc, char **argv ) {
+  discover_queue_init();
+  ofnode_init_table();
+
+  init_trema( &argc, &argv );
+
+  add_periodic_event_callback( DISCOVERING_INTERVAL, discover_path, NULL );
+
+  set_switch_ready_handler( handle_switch_ready, NULL );
+  set_packet_in_handler( handle_packet_in, NULL );
+  set_features_reply_handler( handle_features_reply, NULL );
+
+  start_trema();
+
+  ofnode_destroy();
+  discover_queue_destroy();
+
+  return 0;
+}

--- a/src/examples/discover_path/discover_queue.c
+++ b/src/examples/discover_path/discover_queue.c
@@ -1,0 +1,122 @@
+/*
+ * Author: Hiroyasu OHYAMA
+ *
+ * Copyright (C) 2012 Univ. of tsukuba
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#include <pthread.h>
+#include "trema.h"
+
+#include "discover_queue.h"
+#include "ofnode.h"
+
+static struct discover_queue_head qhead;
+
+void
+discover_queue_init() {
+  create_list( &qhead.head );
+
+  pthread_mutexattr_t attr;
+  pthread_mutexattr_init( &attr );
+  pthread_mutexattr_settype( &attr, PTHREAD_MUTEX_ADAPTIVE_NP );
+
+  qhead.mutex = xmalloc( sizeof( pthread_mutex_t ) );
+  pthread_mutex_init( qhead.mutex, &attr );
+}
+
+void
+discover_queue_destroy() {
+  pthread_mutex_lock( qhead.mutex );
+
+  list_element *elem = qhead.head;
+  while( elem != NULL ) {
+    list_element *next = elem->next;
+
+    xfree( elem->data );
+
+    elem = next;
+  }
+  delete_list( qhead.head );
+
+  pthread_mutex_unlock( qhead.mutex );
+
+  pthread_mutex_destroy( qhead.mutex );
+  xfree( qhead.mutex );
+}
+
+void
+discover_queue_push_switch( uint64_t target, uint64_t from, uint16_t in_port ) {
+
+  discover_queue_entry *entry = xmalloc( sizeof( discover_queue_entry ) );
+  entry->target_dpid = target;
+  entry->type = TYPE_SWITCH;
+
+  entry->from_dpid = from;
+  entry->in_port = in_port;
+
+  pthread_mutex_lock( qhead.mutex );
+
+  insert_in_front( &qhead.head, entry );
+
+  pthread_mutex_unlock( qhead.mutex );
+}
+
+void
+discover_queue_push_host( uint64_t target, uint8_t *mac_addr, uint32_t nw_addr, uint16_t in_port ) {
+  discover_queue_entry *entry = xmalloc( sizeof( discover_queue_entry ) );
+  entry->target_dpid = target;
+  entry->type = TYPE_HOST;
+
+  entry->nw_addr = nw_addr;
+  entry->in_port = in_port;
+  memcpy( entry->mac_addr, mac_addr, ETH_ADDRLEN );
+
+  pthread_mutex_lock( qhead.mutex );
+
+  insert_in_front( &qhead.head, entry );
+
+  pthread_mutex_unlock( qhead.mutex );
+}
+
+void
+discover_queue_push( discover_queue_entry *entry ) {
+  pthread_mutex_lock( qhead.mutex );
+
+  if ( entry != NULL ) {
+    insert_in_front( &qhead.head, entry );
+  }
+
+  pthread_mutex_unlock( qhead.mutex );
+}
+
+discover_queue_entry *
+discover_queue_pop() {
+  discover_queue_entry *entry = NULL;
+
+  pthread_mutex_lock( qhead.mutex );
+
+  list_element *elem = qhead.head;
+  if ( elem != NULL ) {
+    entry = ( discover_queue_entry * ) elem->data;
+
+    delete_element( &qhead.head, entry );
+  }
+
+  pthread_mutex_unlock( qhead.mutex );
+
+  return entry;
+}

--- a/src/examples/discover_path/discover_queue.h
+++ b/src/examples/discover_path/discover_queue.h
@@ -1,0 +1,49 @@
+/*
+ * Author: Hiroyasu OHYAMA
+ *
+ * Copyright (C) 2012 Univ. of tsukuba
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#ifndef __DISCOVERY_QUEUE__
+#define __DISCOVERY_QUEUE__
+
+typedef struct {
+  uint8_t type;
+  uint64_t target_dpid;
+  uint16_t in_port;
+
+  // attribute for switch
+  uint64_t from_dpid;
+
+  // attribute for host
+  uint8_t mac_addr[ ETH_ADDRLEN ];
+  uint32_t nw_addr;
+} discover_queue_entry;
+
+struct discover_queue_head {
+  pthread_mutex_t *mutex;
+  list_element *head;
+};
+
+void discover_queue_init( void );
+void discover_queue_destroy( void );
+void discover_queue_push_switch( uint64_t, uint64_t, uint16_t );
+void discover_queue_push_host( uint64_t, uint8_t *, uint32_t, uint16_t );
+void discover_queue_push( discover_queue_entry * );
+discover_queue_entry *discover_queue_pop();
+
+#endif

--- a/src/examples/discover_path/network.conf
+++ b/src/examples/discover_path/network.conf
@@ -1,0 +1,37 @@
+vswitch("node01") { 
+  datapath_id "0x10001" 
+}
+
+vswitch("node02") { 
+  datapath_id "0x10002" 
+}
+
+vswitch("node03") { 
+  datapath_id "0x10003" 
+}
+
+vswitch("node04") { 
+  datapath_id "0x10004" 
+}
+
+vhost("host1") {
+  ip "192.168.0.1"
+  netmask "255.255.255.0"
+  mac "00:00:00:01:01:01"
+}
+
+vhost("host2") {
+  ip "192.168.0.2"
+  netmask "255.255.255.0"
+  mac "00:00:00:01:01:02"
+}
+
+link "node01", "node02"
+link "node01", "node03"
+
+link "node02", "node03"
+link "node03", "node04"
+link "node04", "node02"
+
+link "node01", "host1"
+link "node04", "host2"

--- a/src/examples/discover_path/ofnode.c
+++ b/src/examples/discover_path/ofnode.c
@@ -1,0 +1,227 @@
+/*
+ * Author: Hiroyasu OHYAMA
+ *
+ * Copyright (C) 2012 Univ. of tsukuba
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#include "ofnode.h"
+
+#define STRLEN ( 256 )
+
+/* Switch Info Table */
+struct ofnode *ofnode_table[ NODE_MAX ];
+
+static void do_remove( struct ofnode * );
+static char *mac2str( uint8_t *, int );
+
+void
+ofnode_init_table() {
+  int i;
+
+  for ( i = 0; i < NODE_MAX; i++ ) {
+    ofnode_table[ i ] = NULL;
+  }
+}
+
+struct ofnode *
+ofnode_get_switch( uint64_t dpid ) {
+  struct ofnode *node = NULL;
+  int i;
+
+  for ( i = 0; i < NODE_MAX; i++ ) {
+    struct ofnode *tnode = ofnode_table[ i ];
+
+    if ( ( tnode != NULL ) 
+        && ( tnode->type == TYPE_SWITCH ) 
+        && ( tnode->switch_info.dpid == dpid ) ) {
+      node = tnode;
+      break;
+    }
+  }
+
+  return node;
+}
+
+struct ofnode *
+ofnode_get_host( uint32_t nwaddr ) {
+  struct ofnode *node = NULL;
+  int i;
+
+  for ( i = 0; i < NODE_MAX; i++ ) {
+    struct ofnode *tnode = ofnode_table[ i ];
+
+    if ( ( tnode != NULL ) 
+        && ( tnode->type == TYPE_HOST ) 
+        && ( tnode->host_info.nwaddr == nwaddr ) ) {
+      node = tnode;
+      break;
+    }
+  }
+
+  return node;
+}
+
+struct ofnode *
+ofnode_create_switch( uint64_t dpid, uint16_t len ) {
+  struct ofnode *node = NULL;
+  int i;
+
+  /* checking the ofnode object that has required feature is */
+  node = ofnode_get_switch( dpid );
+  if ( node != NULL) {
+    return node;
+  }
+
+  for ( i = 0; i < NODE_MAX; i++ ) {
+    if ( ofnode_table[ i ] == NULL ) {
+      node = xmalloc( sizeof( struct ofnode ) );
+
+      node->type = TYPE_SWITCH;
+      node->switch_info.dpid = dpid;
+      node->switch_info.port_len = len;
+      node->switch_info.ports = xmalloc( sizeof( struct ofnode * ) * len );
+      memset( node->switch_info.ports, 0, sizeof( struct ofnode * ) * len );
+
+      ofnode_table[ i ] = node;
+
+      break;
+    }
+  }
+
+  return node;
+}
+
+struct ofnode *
+ofnode_create_host( uint8_t *mac_addr, uint32_t nw_addr ) {
+  struct ofnode *node = NULL;
+  int i;
+
+  /* checking the ofnode object that has required feature is */
+  node = ofnode_get_host( nw_addr );
+  if ( node != NULL ) {
+    return node;
+  }
+
+  for ( i = 0; i < NODE_MAX; i++ ) {
+    if ( ofnode_table[ i ] == NULL ) {
+      node = xmalloc( sizeof( struct ofnode ) );
+
+      node->type = TYPE_HOST;
+      node->host_info.nwaddr = nw_addr;
+      memcpy( node->host_info.macaddr, mac_addr, ETH_ADDRLEN );
+
+      ofnode_table[ i ] = node;
+
+      break;
+    }
+  }
+
+  return node;
+}
+
+void 
+ofnode_remove( struct ofnode *node ) {
+  int i;
+
+  for ( i = 0; i < NODE_MAX; i++ ) {
+    if ( ofnode_table[ i ] == node ) {
+      do_remove( node );
+
+      ofnode_table[ i ] = NULL;
+    }
+  }
+}
+
+void
+ofnode_destroy() {
+  int i;
+
+  for ( i = 0; i < NODE_MAX; i++ ) {
+    do_remove( ofnode_table[ i ] );
+
+    ofnode_table[ i ] = NULL;
+  }
+}
+
+void
+ofnode_show_table() {
+  int i;
+
+  for ( i = 0; i < NODE_MAX; i++ ) {
+    struct ofnode *node = ofnode_table[ i ];
+    if ( ( node != NULL ) && ( node->type == TYPE_SWITCH ) ) {
+
+      int p_num;
+      for ( p_num = 1; p_num < node->switch_info.port_len; p_num++ ) {
+        char str[ STRLEN ];
+        struct ofnode *tonode = node->switch_info.ports[ p_num ];
+        int offset;
+
+        offset = sprintf( str, "[ ofnode_show_table ] dpid:%llx, port_no:%d => ", 
+            node->switch_info.dpid, p_num );
+
+        if ( tonode != NULL ) {
+          if ( tonode->type == TYPE_SWITCH ) {
+            /* seting switch infomation */
+
+            offset += sprintf( str + offset, "switch ( dpid:%llx )", tonode->switch_info.dpid );
+
+          } else if ( tonode->type == TYPE_HOST ) {
+            /* setting host infomation */
+
+            struct in_addr addr;
+            addr.s_addr = ntohl( tonode->host_info.nwaddr );
+
+            offset += sprintf( str + offset, "host ( macaddr:%s, nw_addr:%s )", 
+                mac2str( tonode->host_info.macaddr, ETH_ADDRLEN ), inet_ntoa( addr ) );
+
+          }
+        }
+
+        info( "%s", str );
+      }
+    }
+  }
+}
+
+static void 
+do_remove( struct ofnode *node ) {
+  if ( node != NULL ) {
+    if ( node->type == TYPE_SWITCH ) {
+      xfree( node->switch_info.ports );
+    }
+
+    xfree( node );
+  }
+}
+
+static char *
+mac2str( uint8_t *addr, int len ) {
+  static char str[ STRLEN ];
+  int i, offset;
+
+  memset( str, 0, STRLEN );
+  for ( i = offset = 0; i < len; i++ ) {
+    if ( i == ( len - 1 ) ) {
+      sprintf( str + offset, "%02x", addr[ i ] );
+    } else {
+      offset += sprintf( str + offset, "%02x:", addr[ i ] );
+    }
+  }
+
+  return str;
+}

--- a/src/examples/discover_path/ofnode.h
+++ b/src/examples/discover_path/ofnode.h
@@ -1,0 +1,58 @@
+/*
+ * Author: Hiroyasu OHYAMA
+ *
+ * Copyright (C) 2012 Univ. of tsukuba
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#ifndef __ofswitch_h__
+#define __ofswitch_h__
+
+#include "trema.h"
+
+#define NODE_MAX ( 512 )
+
+#define TYPE_SWITCH ( 0x1 )
+#define TYPE_HOST ( 0x2 )
+
+/* OpenFlow node, which means switch or host, infomation */
+struct ofnode {
+  uint32_t type;
+  union {
+    struct {
+      uint64_t dpid;
+      uint16_t port_len;
+      struct ofnode **ports;
+    } switch_info;
+
+    struct {
+      uint8_t macaddr[ ETH_ADDRLEN ];
+      uint32_t nwaddr;
+      void *data;
+    } host_info;
+  };
+};
+
+void ofnode_init_table( void );
+struct ofnode *ofnode_get_switch( uint64_t );
+struct ofnode *ofnode_get_host( uint32_t );
+struct ofnode *ofnode_create_switch( uint64_t, uint16_t );
+struct ofnode *ofnode_create_host( uint8_t *, uint32_t );
+void ofnode_remove( struct ofnode * );
+void ofnode_destroy( void );
+void ofnode_show_table( void );
+
+#endif


### PR DESCRIPTION
I made an example that discovers all the path that are connected to a node, which means switch or host, through a physical port.

This example generate and send a discovery-frame that only have source-addr of switch to OFPP_FLOOD vertual-port when switches are ready.
Then, each switches send packet-in message to controller and it can be to know which switches are connected from nodes through a specific physical port.

To detect position where is a host, this controller also listens for the transmission of the packet from the host with Packet-in handler. Then check the current network topology.
If the host which sends this packet is not registerd, this controller update the topology information.

The core data structure is following.

```
/* OpenFlow node, which means switch or host, infomation */
struct ofnode {
  uint32_t type;
  union {
    struct {
      uint64_t dpid;
      uint16_t port_len;
      struct ofnode **ports;
    } switch_info;

    struct {
      uint8_t macaddr[ ETH_ADDRLEN ];
      uint32_t nwaddr;
      void *data;
    } host_info;
  };
};
```

Parameters of "ports" and "port_len" at switch_info are initizlied at event handler of Feature-Reply message.
And this controller makes up relationship of these objects as described above.
