### PR TITLE
add check process name processing into read_pid()

### DIFF
--- a/unittests/lib/daemon_test.c
+++ b/unittests/lib/daemon_test.c
@@ -22,6 +22,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -155,6 +156,28 @@ mock_kill( pid_t pid, int sig ) {
   check_expected( pid );
   check_expected( sig );
   return ( int ) mock();
+}
+
+
+static size_t link_length = 0;
+static char *link_buffer = NULL;
+
+ssize_t
+mock_readlink( const char *path, char *buf, size_t bufsiz ) {
+  check_expected( path );
+  check_expected( buf );
+  check_expected( bufsiz );
+  if ( link_length > 0 ) {
+    memcpy( buf, link_buffer, link_length );
+  }
+  return ( ssize_t ) mock();
+}
+
+
+char *
+mock_basename( char *path ) {
+  check_expected( path );
+  return ( char * ) mock();
 }
 
 
@@ -348,13 +371,27 @@ test_read_pid_successed() {
   read_length = strlen( valid_pid_string );
   will_return( mock_read, read_length );
 
-  // Test if correctly read.
+  // Test if correctly kill.
   expect_value( mock_kill, pid, valid_pid );
   expect_value( mock_kill, sig, 0 );
   will_return( mock_kill, 0 );
 
   // Test if correctly close.
   expect_value( mock_close, fd, pid_file_fd );
+
+  // Test if correctly readlink.
+  char proc_path[] = "/proc/123/exe";
+  expect_string( mock_readlink, path, proc_path );
+  expect_not_value( mock_readlink, buf, NULL );
+  expect_value( mock_readlink, bufsiz, PATH_MAX );
+  char valid_exe_path[] = "/home/yasuhito/trema/bin/chess";
+  link_buffer = valid_exe_path;
+  link_length = strlen( valid_exe_path );
+  will_return( mock_readlink, link_length );
+
+  // Test if correctly basename.
+  expect_string( mock_basename, path, valid_exe_path );
+  will_return( mock_basename, strdup( "chess" ) );
 
   // Go
   pid_t pid = read_pid( "/home/yasuhito/trema/tmp", "chess" );
@@ -578,6 +615,105 @@ test_read_pid_fail_if_kill_fail_with_EPERM() {
 
 
 static void
+test_read_pid_fail_if_readlink_fail() {
+  // Test if correctly access.
+  char path[] = "/home/yasuhito/trema/tmp/chess.pid";
+  expect_string( mock_access, pathname, path );
+  expect_value( mock_access, mode, R_OK );
+  will_return( mock_access, 0 );
+
+  // Test if correctly opened.
+  int pid_file_fd = 111;
+  expect_string( mock_open, pathname, path );
+  expect_value( mock_open, flags, O_RDONLY );
+  expect_value( mock_open, mode, 0 );
+  will_return( mock_open, pid_file_fd );
+
+  // Test if correctly read.
+  expect_value( mock_read, fd, pid_file_fd );
+  expect_not_value( mock_read, buf, NULL );
+  expect_value( mock_read, count, 10 - 1 );
+  char valid_pid_string[] = "123\n";
+  pid_t valid_pid = 123;
+  read_buffer = valid_pid_string;
+  read_length = strlen( valid_pid_string );
+  will_return( mock_read, read_length );
+
+  // Test if correctly kill.
+  expect_value( mock_kill, pid, valid_pid );
+  expect_value( mock_kill, sig, 0 );
+  will_return( mock_kill, 0 );
+
+  // Test if correctly close.
+  expect_value( mock_close, fd, pid_file_fd );
+
+  // Test if correctly readlink.
+  char proc_path[] = "/proc/123/exe";
+  expect_string( mock_readlink, path, proc_path );
+  expect_not_value( mock_readlink, buf, NULL );
+  expect_value( mock_readlink, bufsiz, PATH_MAX );
+  will_return( mock_readlink, -1 );
+
+  // Go
+  pid_t pid = read_pid( "/home/yasuhito/trema/tmp", "chess" );
+  assert_true( pid == -1 );
+}
+
+
+static void
+test_read_pid_fail_if_strcmp_fail() {
+  // Test if correctly access.
+  char path[] = "/home/yasuhito/trema/tmp/chess.pid";
+  expect_string( mock_access, pathname, path );
+  expect_value( mock_access, mode, R_OK );
+  will_return( mock_access, 0 );
+
+  // Test if correctly opened.
+  int pid_file_fd = 111;
+  expect_string( mock_open, pathname, path );
+  expect_value( mock_open, flags, O_RDONLY );
+  expect_value( mock_open, mode, 0 );
+  will_return( mock_open, pid_file_fd );
+
+  // Test if correctly read.
+  expect_value( mock_read, fd, pid_file_fd );
+  expect_not_value( mock_read, buf, NULL );
+  expect_value( mock_read, count, 10 - 1 );
+  char valid_pid_string[] = "123\n";
+  pid_t valid_pid = 123;
+  read_buffer = valid_pid_string;
+  read_length = strlen( valid_pid_string );
+  will_return( mock_read, read_length );
+
+  // Test if correctly kill.
+  expect_value( mock_kill, pid, valid_pid );
+  expect_value( mock_kill, sig, 0 );
+  will_return( mock_kill, 0 );
+
+  // Test if correctly close.
+  expect_value( mock_close, fd, pid_file_fd );
+
+  // Test if correctly readlink.
+  char proc_path[] = "/proc/123/exe";
+  expect_string( mock_readlink, path, proc_path );
+  expect_not_value( mock_readlink, buf, NULL );
+  expect_value( mock_readlink, bufsiz, PATH_MAX );
+  char INVALID_exe_path[] = "/home/yasuhito/trema/bin/chess2";
+  link_buffer = INVALID_exe_path;
+  link_length = strlen( INVALID_exe_path );
+  will_return( mock_readlink, link_length );
+
+  // Test if correctly basename.
+  expect_string( mock_basename, path, INVALID_exe_path );
+  will_return( mock_basename, strdup( "chess2" ) );
+
+  // Go
+  pid_t pid = read_pid( "/home/yasuhito/trema/tmp", "chess" );
+  assert_true( pid == -1 );
+}
+
+
+static void
 test_rename_pid_successed() {
   // Test if correctly unlink.
   expect_string( mock_unlink, pathname, "/home/yasuhito/trema/tmp/hello.pid" );
@@ -646,6 +782,8 @@ main() {
     unit_test( test_read_pid_fail_if_pid_is_zero ),
     unit_test( test_read_pid_fail_if_kill_fail_with_ESRCH ),
     unit_test( test_read_pid_fail_if_kill_fail_with_EPERM ),
+    unit_test( test_read_pid_fail_if_readlink_fail ),
+    unit_test( test_read_pid_fail_if_strcmp_fail ),
 
     // rename_pid() tests.
     unit_test( test_rename_pid_successed ),


### PR DESCRIPTION
read_pid()にプロセス名チェック処理を追加しました。
switchプロセスのpidファイルからswitchプロセスの生存をチェックしていますが、switchプロセスが使用していたpidが再利用されてしまった場合、無関係のプロセスをkillしてしまう恐れがあったので、本当にswitchプロセスかを検査するようにしました。
ご検討をお願いいたします。
