### PR TITLE
Fix readlink usage. 

### DIFF
--- a/src/lib/daemon.c
+++ b/src/lib/daemon.c
@@ -282,11 +282,12 @@ read_pid( const char *directory, const char *name ) {
   char proc_path[ 32 ];
   char exe_path[ PATH_MAX ];
   sprintf( proc_path, "/proc/%d/exe", pid );
-  ssize_t readsiz = readlink( proc_path, exe_path, sizeof( exe_path ) );
+  ssize_t readsiz = readlink( proc_path, exe_path, sizeof( exe_path ) - 1 );
   if ( readsiz == -1 ) {
     warn( "Failed to check process id %d ( %s [%d] ).", pid, strerror( errno ), errno );
     return -1;
   }
+  exe_path[ readsiz ] = '\0';
 
   char *exe_name = basename( exe_path );
   if ( strcmp( name, exe_name ) != 0 ) {

--- a/unittests/lib/daemon_test.c
+++ b/unittests/lib/daemon_test.c
@@ -175,7 +175,7 @@ mock_readlink( const char *path, char *buf, size_t bufsiz ) {
 char *
 mock_basename( char *path ) {
   check_expected( path );
-  return ( char * ) mock();
+  return ( char * )( intptr_t )  mock();
 }
 
 
@@ -381,7 +381,7 @@ test_read_pid_successed() {
   char proc_path[] = "/proc/123/exe";
   expect_string( mock_readlink, path, proc_path );
   expect_not_value( mock_readlink, buf, NULL );
-  expect_value( mock_readlink, bufsiz, PATH_MAX );
+  expect_value( mock_readlink, bufsiz, PATH_MAX - 1 );
   char valid_exe_path[] = "/home/yasuhito/trema/bin/chess";
   link_buffer = valid_exe_path;
   link_length = strlen( valid_exe_path );
@@ -649,7 +649,7 @@ test_read_pid_fail_if_readlink_fail() {
   char proc_path[] = "/proc/123/exe";
   expect_string( mock_readlink, path, proc_path );
   expect_not_value( mock_readlink, buf, NULL );
-  expect_value( mock_readlink, bufsiz, PATH_MAX );
+  expect_value( mock_readlink, bufsiz, PATH_MAX - 1 );
   will_return( mock_readlink, -1 );
 
   // Go
@@ -695,7 +695,7 @@ test_read_pid_fail_if_strcmp_fail() {
   char proc_path[] = "/proc/123/exe";
   expect_string( mock_readlink, path, proc_path );
   expect_not_value( mock_readlink, buf, NULL );
-  expect_value( mock_readlink, bufsiz, PATH_MAX );
+  expect_value( mock_readlink, bufsiz, PATH_MAX - 1 );
   char INVALID_exe_path[] = "/home/yasuhito/trema/bin/chess2";
   link_buffer = INVALID_exe_path;
   link_length = strlen( INVALID_exe_path );


### PR DESCRIPTION
[#211](https://github.com/trema/trema/issues/211)で発生中のビルドエラーに対する修正です。
- コンパイルエラーの修正
  - ポインタと同サイズの整数に変換してからポインタに変換するように。
- [readlinkはバッファをNULL終端しない事への対処](https://www.fortify.com/vulncat/ja/vulncat/cpp/often_misused_file_system_readlink.html)
  - 後にNULL文字セットのためreadlinkの第3引数をバッファサイズ-1の指定へ変更
  - readlink成功後にNULL終端文字挿入
