### PR TITLE
fix issue where vendor's action body was not set

### DIFF
--- a/ruby/trema/controller.c
+++ b/ruby/trema/controller.c
@@ -131,9 +131,9 @@ append_action( openflow_actions *actions, VALUE action ) {
       Check_Type( rbody, T_ARRAY );
       uint16_t length = ( uint16_t ) RARRAY_LEN( rbody );
       buffer *body = alloc_buffer_with_length( length );
-      int i;
-      for ( i = 0; i < length; i++ ) {
-        ( ( uint8_t * ) body->data )[ i ] = ( uint8_t ) FIX2INT( RARRAY_PTR( rbody )[ i ] );
+      void *p = append_back_buffer( body, length );
+      for ( int i = 0; i < length; i++ ) {
+        ( ( uint8_t * ) p )[ i ] = ( uint8_t ) FIX2INT( RARRAY_PTR( rbody )[ i ] );
       }
       append_action_vendor( actions, ( uint32_t ) NUM2UINT( vendor_id ), body );
       free_buffer( body );


### PR DESCRIPTION
Takamiya-san

Please find a fix to the above problem. The append_back_buffer was missing therefore no body 
was set. I confirmed that the library call append_action_vendor displays the correct body length but I have no application to check further but should work.

Kind regards

Nick
