### PR TITLE
Track .h to .h dependencies.

### DIFF
--- a/Rantfile
+++ b/Rantfile
@@ -379,7 +379,7 @@ end
 task dependency( "libtrema" ) => "vendor:openflow"
 gen C::Dependencies, dependency( "libtrema" ),
   :search => [ Trema.include, objects( "openflow" ) ],
-  :sources => sys[ "#{ Trema.include }/*.c" ]
+  :sources => sys[ "#{ Trema.include }/*.{c,h}" ]
 
 gen Action do
   source dependency( "libtrema" )
@@ -448,7 +448,7 @@ end
 switch_manager_objects_dir = objects( "switch_manager" )
 
 gen C::Dependencies, dependency( "switch_manager" ),
-  :search => [ "src/switch_manager", Trema.include ], :sources => sys[ "src/switch_manager/*.c" ]
+  :search => [ "src/switch_manager", Trema.include ], :sources => sys[ "src/switch_manager/*.{c,h}" ]
 
 gen Action do
   source dependency( "switch_manager" )
@@ -502,7 +502,7 @@ end
 ################################################################################
 
 gen C::Dependencies, dependency( "packetin_filter" ),
-  :search => [ "src/packetin_filter", Trema.include ], :sources => sys[ "src/packetin_filter/*.c" ]
+  :search => [ "src/packetin_filter", Trema.include ], :sources => sys[ "src/packetin_filter/*.{c,h}" ]
 
 gen Action do
   source dependency( "packetin_filter" )
@@ -529,7 +529,7 @@ end
 tremashark_objects_dir = objects( "tremashark" )
 
 gen C::Dependencies, dependency( "tremashark" ),
-  :search => [ "src/tremashark", Trema.include ], :sources => sys[ "src/tremashark/*.c" ]
+  :search => [ "src/tremashark", Trema.include ], :sources => sys[ "src/tremashark/*.{c,h}" ]
 
 gen Action do
   source dependency( "tremashark" )
@@ -613,7 +613,7 @@ management_source_dir = "src/management"
 management_objects_dir = objects( "management" )
 
 gen C::Dependencies, dependency( "management" ),
-  :search => [ Trema.include ], :sources => sys[ "#{ management_source_dir }/*.c" ]
+  :search => [ Trema.include ], :sources => sys[ "#{ management_source_dir }/*.{c,h}" ]
 
 gen Action do
   source dependency( "management" )
@@ -660,7 +660,7 @@ standalone_examples.each do | each |
   target = objects( "examples/#{ each }/#{ each }" )
 
   gen C::Dependencies, dependency( each ),
-    :search => [ "src/examples/#{ each }", Trema.include ], :sources => sys[ "src/examples/#{ each }/*.c" ]
+    :search => [ "src/examples/#{ each }", Trema.include ], :sources => sys[ "src/examples/#{ each }/*.{c,h}" ]
 
   gen Action do
     source dependency( each )
@@ -695,7 +695,7 @@ openflow_switch_source_dir = "src/examples/openflow_switch"
 openflow_switch_objects_dir = objects( "examples/openflow_switch" )
 
 gen C::Dependencies, dependency( "openflow_switch" ),
-  :search => [ Trema.include ], :sources => sys[ "#{ openflow_switch_source_dir }/*.c" ]
+  :search => [ Trema.include ], :sources => sys[ "#{ openflow_switch_source_dir }/*.{c,h}" ]
 
 gen Action do
   source dependency( "openflow_switch" )
@@ -734,7 +734,7 @@ openflow_message_source_dir = "src/examples/openflow_message"
 openflow_message_objects_dir = objects( "examples/openflow_message" )
 
 gen C::Dependencies, dependency( "openflow_message" ),
-  :search => [ Trema.include ], :sources => sys[ "#{ openflow_message_source_dir }/*.c" ]
+  :search => [ Trema.include ], :sources => sys[ "#{ openflow_message_source_dir }/*.{c,h}" ]
 
 gen Action do
   source dependency( "openflow_message" )
@@ -773,7 +773,7 @@ packetin_filter_config_source_dir = "src/examples/packetin_filter_config"
 packetin_filter_config_objects_dir = objects( "examples/packetin_filter_config" )
 
 gen C::Dependencies, dependency( "packetin_filter_config" ),
-  :search => [ Trema.include ], :sources => sys[ "#{ packetin_filter_config_source_dir }/*.c" ]
+  :search => [ Trema.include ], :sources => sys[ "#{ packetin_filter_config_source_dir }/*.{c,h}" ]
 
 gen Action do
   source dependency( "packetin_filter_config" )
@@ -836,7 +836,7 @@ end
 
 
 gen C::Dependencies, dependency( "unittests" ),
-  :search => [ Trema.include, "unittests" ], :sources => sys[ "unittests/lib/*.c", "src/lib/*.c" ]
+  :search => [ Trema.include, "unittests" ], :sources => sys[ "unittests/lib/*.c", "src/lib/*.{c,h}" ]
 
 gen Action do
   source dependency( "unittests" )


### PR DESCRIPTION
リビルド時の漏れを防ぐため、.c から直接includeされている.hだけでなく、
.hから間接的にincludeされている.h への依存関係も追跡するように修正。
