### PR TITLE
Removed openflow_h's dependency to objects dir

### DIFF
--- a/Rantfile
+++ b/Rantfile
@@ -235,8 +235,9 @@ task :distclean => [
 gen Directory, Trema.objects
 
 task "vendor:openflow" => Trema.openflow_h
-file Trema.openflow_h => Trema.objects do
+file Trema.openflow_h do
   sys.unpack_tgz "#{ Trema.vendor_openflow }.tar.gz", :in => Trema.vendor
+  sys.mkdir_p Trema.objects
   sys.cp_r "#{ Trema.vendor_openflow }/include/openflow", Trema.objects
   sys "chmod -R +r #{ File.join Trema.objects, "openflow" }"
 end


### PR DESCRIPTION
objects ディレクトリとの間に依存関係が設定されているため、
objects ディレクトリのタイムスタンプに変更があった場合、
無用にリビルドが発生してしまうことを回避する。

問題の概要：
clean後などの状態で./build.rbした場合、openflow.h がコピーされた後、
他のvendors等のファイルが展開されるためobjectsディレクトリが更新された状態となる。
結果、次回 ./build.rbを実行時に再度openflow.h がコピーされ、
同ファイルに依存するファイルのリビルドを引き起こしてしまう。
