### PR TITLE
[trema]/tmp/ dirs should be created before running tests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,18 +83,21 @@ begin
   require "rspec/core"
   require "rspec/core/rake_task"
 
+  task :spec => [ :build ]
   RSpec::Core::RakeTask.new do | task |
     task.verbose = $trace
     task.pattern = FileList[ "spec/**/*_spec.rb" ]
     task.rspec_opts = "--format documentation --color"
   end
 
+  task "spec:actions" => [ :build ]
   RSpec::Core::RakeTask.new( "spec:actions" ) do | task |
     task.verbose = $trace
     task.pattern = FileList[ "spec/**/*_spec.rb" ]
     task.rspec_opts = "--tag type:actions --format documentation --color"
   end
 
+  task :rcov => [ :build ]
   RSpec::Core::RakeTask.new( :rcov ) do | spec |
     spec.pattern = "spec/**/*_spec.rb"
     spec.rcov = true
@@ -107,6 +110,7 @@ end
 
 begin
   require "cucumber/rake/task"
+  task :features => [ :build ]
   Cucumber::Rake::Task.new( :features ) do | t |
     t.cucumber_opts = "features --tags ~@wip"
   end


### PR DESCRIPTION
./cruise.rb and other tests fail, when [trema]/tmp/ directories did not exist.

This patch will creates the tmp and it's subdirectories before running tests.

This patch should fix the 1st issue reported in #263
