### PR TITLE
Workaround for Relish rendering #258

### DIFF
--- a/features/.nav
+++ b/features/.nav
@@ -20,6 +20,10 @@
     - delete_forward_entry.feature
     - dump_forward_entries.feature
     - set_forward_entries.feature
+    - C-add_forward_entry.feature
+    - C-delete_forward_entry.feature
+    - C-dump_forward_entries.feature
+    - C-set_forward_entries.feature
   - hello_trema.feature
   - list_switches.feature
   - switch_monitor.feature

--- a/features/examples/switch-event/add_forward_entry.feature
+++ b/features/examples/switch-event/add_forward_entry.feature
@@ -9,18 +9,18 @@ Feature: Ruby methods for adding switch event forwarding entry.
   These methods can be used by including the Trema::SwitchEvent module
   in user controller code. 
   
-  ** add_forward_entry_to_all_switches event_type, trema_name **
+  * ** add_forward_entry_to_all_switches event_type, trema_name **
   
   This method will add `trema_name` to all existing switches and switch manager's 
   event forwarding entry list of the specified `event_type`.  
   
-  ** add_forward_entry_to_switch dpid, event_type, trema_name **
+  * ** add_forward_entry_to_switch dpid, event_type, trema_name **
   
   This method will add an entry to a switch specified by `dpid`. 
   It will add `trema_name` to the switch's 
   event forwarding entry list of the specified `event_type`.  
   
-  ** add_forward_entry_to_switch_manager event_type, trema_name **
+  * ** add_forward_entry_to_switch_manager event_type, trema_name **
   
   This method will add `trema_name` to the switch manager's 
   event forwarding entry list of the specified `event_type`.  

--- a/features/examples/switch-event/delete_forward_entry.feature
+++ b/features/examples/switch-event/delete_forward_entry.feature
@@ -9,18 +9,18 @@ Feature: Ruby methods for deleting switch event forwarding entry.
   These methods can be used by including the Trema::SwitchEvent module
   in user controller code. 
   
-  ** delete_forward_entry_from_all_switches event_type, trema_name **
+  * ** delete_forward_entry_from_all_switches event_type, trema_name **
   
   This method will delete `trema_name` from all existing switches and switch manager's 
   event forwarding entry list of the specified `event_type`.  
   
-  ** delete_forward_entry_from_switch dpid, event_type, trema_name **
+  * ** delete_forward_entry_from_switch dpid, event_type, trema_name **
   
   This method will delete an entry from switch specified by `dpid`. 
   It will delete `trema_name` from the switch's 
   event forwarding entry list of the specified `event_type`.  
   
-  ** delete_forward_entry_from_switch_manager event_type, trema_name **
+  * ** delete_forward_entry_from_switch_manager event_type, trema_name **
   
   This method will delete `trema_name` from the switch manager's 
   event forwarding entry list of the specified `event_type`.  

--- a/features/examples/switch-event/dump_forward_entries.feature
+++ b/features/examples/switch-event/dump_forward_entries.feature
@@ -8,13 +8,13 @@ Feature: Ruby methods for dumping switch event forwarding entry.
   These methods can be used by including the Trema::SwitchEvent module
   in user controller code. 
   
-  ** dump_forward_entries_from_switch dpid, event_type **
+  * ** dump_forward_entries_from_switch dpid, event_type **
   
   This method will dump the forwarding entries of the switch specified by `dpid`. 
   It will dump the content of the the switch's 
   event forwarding entry list of the specified `event_type`.  
   
-  ** dump_forward_entries_from_switch_manager event_type **
+  * ** dump_forward_entries_from_switch_manager event_type **
   
   This method will dump the content of the the switch manager's 
   event forwarding entry list of the specified `event_type`.  

--- a/features/examples/switch-event/set_forward_entries.feature
+++ b/features/examples/switch-event/set_forward_entries.feature
@@ -8,7 +8,7 @@ Feature: Ruby methods for setting switch event forwarding entry.
   These methods can be used by including the Trema::SwitchEvent module
   in user controller code. 
   
-  ** set_forward_entries_to_switch dpid, event_type, trema_names **
+  * ** set_forward_entries_to_switch dpid, event_type, trema_names **
   
   This method will set the forwarding entries of the switch specified by `dpid`. 
   It will replace the switch's 
@@ -16,7 +16,7 @@ Feature: Ruby methods for setting switch event forwarding entry.
   to Array of trema-names specified by `trema_names`. 
     
   
-  ** set_forward_entries_to_switch_manager event_type, trema_names **
+  * ** set_forward_entries_to_switch_manager event_type, trema_names **
   
   This method will replace the switch manager's 
   event forwarding entry list of the specified `event_type`


### PR DESCRIPTION
- Explicitly place C examples after Ruby methods in .nav file
- Itemize emphasized method names in Ruby .feature description.

https://www.relishapp.com/trema/trema/docs/switch-event/ruby-methods-for-adding-switch-event-forwarding-entry
