### PR TITLE
Unify Switch-Event Feature Style

### DIFF
--- a/features/examples/switch-event/C-add_forward_entry.feature
+++ b/features/examples/switch-event/C-add_forward_entry.feature
@@ -1,10 +1,10 @@
-Feature: "add_forward_entry" C function example command
+Feature: C function example command "add_forward_entry"
   
   Switch Event forwarding configuration command (`add_forward_entry`)
   is a command to add an event forwarding entry to 
   Switch Manager and Switch Daemons.
   
-  The types of switch event can be forwarded are:
+  Following switch event types can be configured by this command:
   
   * vendor
   * packet_in

--- a/features/examples/switch-event/C-delete_forward_entry.feature
+++ b/features/examples/switch-event/C-delete_forward_entry.feature
@@ -1,10 +1,10 @@
-Feature: "delete_forward_entry" C function example command
+Feature: C function example command "delete_forward_entry"
   
   Switch Event forwarding configuration command (`delete_forward_entry`)
   is a command to delete an event forwarding entry from 
   Switch Manager and Switch Daemons.
   
-  The types of switch event can be forwarded are:
+  Following switch event types can be configured by this command:
   
   * vendor
   * packet_in

--- a/features/examples/switch-event/C-dump_forward_entries.feature
+++ b/features/examples/switch-event/C-dump_forward_entries.feature
@@ -1,10 +1,10 @@
-Feature: "dump_forward_entries" C function example command
+Feature: C function example command "dump_forward_entries"
   
   Switch Event forwarding configuration command (`dump_forward_entries`)
   is a command to dump event forwarding entries of 
   Switch Manager and Switch Daemons.
   
-  The types of switch event can be forwarded are:
+  Following switch event types can be configured by this command:
   
   * vendor
   * packet_in

--- a/features/examples/switch-event/C-set_forward_entries.feature
+++ b/features/examples/switch-event/C-set_forward_entries.feature
@@ -1,10 +1,10 @@
-Feature: "set_forward_entries" C function example command
+Feature: C function example command "set_forward_entries"
   
   Switch Event forwarding configuration command (`set_forward_entries`)
   is a command to replace event forwarding entries of 
   Switch Manager and Switch Daemons.
   
-  The types of switch event can be forwarded are:
+  Following switch event types can be configured by this command:
   
   * vendor
   * packet_in

--- a/features/examples/switch-event/add_forward_entry.feature
+++ b/features/examples/switch-event/add_forward_entry.feature
@@ -1,4 +1,4 @@
-Feature: Ruby methods for adding switch event forwarding entry.
+Feature: Ruby methods for adding switch event forwarding entry
   
   There are three Ruby methods provided for adding switch event forwarding entries:
   

--- a/features/examples/switch-event/delete_forward_entry.feature
+++ b/features/examples/switch-event/delete_forward_entry.feature
@@ -1,4 +1,4 @@
-Feature: Ruby methods for deleting switch event forwarding entry.
+Feature: Ruby methods for deleting switch event forwarding entry
   
   There are three Ruby methods provided for deleting switch event forwarding entries.
   

--- a/features/examples/switch-event/dump_forward_entries.feature
+++ b/features/examples/switch-event/dump_forward_entries.feature
@@ -1,4 +1,4 @@
-Feature: Ruby methods for dumping switch event forwarding entry.
+Feature: Ruby methods for dumping switch event forwarding entry
   
   There are two Ruby methods provided for dumping switch event forwarding entry.
   

--- a/features/examples/switch-event/set_forward_entries.feature
+++ b/features/examples/switch-event/set_forward_entries.feature
@@ -1,4 +1,4 @@
-Feature: Ruby methods for setting switch event forwarding entry.
+Feature: Ruby methods for setting switch event forwarding entry
   
   There are two Ruby methods provided for setting switch event forwarding entry.
   


### PR DESCRIPTION
- Remove period
- Make C .feature to look a little closer to Ruby .feature style.

This is an additional fix for trema/trema#289, trema/trema#258
