### PR TITLE
Add @slow_process to potentially slow scenarios.

### DIFF
--- a/features/switch_event/C-add_forward_entry.feature
+++ b/features/switch_event/C-add_forward_entry.feature
@@ -39,6 +39,7 @@ Feature: C function example command "add_forward_entry"
         -t, --type={vendor,packet_in,port_status,state_notify} Specify event type.
       """
 
+  @slow_process
   Scenario Outline: Add 'mirror' to All Switch Manager/Daemon's event forwarding entries of packet_in
     Given a file named "nw_dsl.conf" with:
       """
@@ -60,6 +61,7 @@ Feature: C function example command "add_forward_entry"
       | SW 0x1 | -s 0x1 |
       | SW 0x2 | -s 0x2 |
 
+  @slow_process
   Scenario Outline: Switch added after event forwarding entry manipulation should also reflect new configuration of Switch Manager.
     Given a file named "nw_dsl.conf" with:
       """
@@ -87,6 +89,7 @@ Feature: C function example command "add_forward_entry"
       | SW 0x1 | -s 0x1 |
       | SW 0x2 | -s 0x2 |
 
+  @slow_process
   Scenario Outline: Add 'mirror' only to Switch Manager's event forwarding entry of packet_in
     Given a file named "nw_dsl.conf" with:
       """
@@ -108,6 +111,7 @@ Feature: C function example command "add_forward_entry"
       | 0x1    |
       | 0x2    |
 
+  @slow_process
   Scenario Outline: Add 'mirror' only to Switch Daemon 0x1's event forwarding entries of packet_in
     Given a file named "nw_dsl.conf" with:
       """

--- a/features/switch_event/C-delete_forward_entry.feature
+++ b/features/switch_event/C-delete_forward_entry.feature
@@ -39,6 +39,7 @@ Feature: C function example command "delete_forward_entry"
         -t, --type={vendor,packet_in,port_status,state_notify} Specify event type.
       """
 
+  @slow_process
   Scenario Outline: Delete 'RepeaterHub' from All Switch Manager/Daemon's event forwarding entries of packet_in
     Given a file named "nw_dsl.conf" with:
       """
@@ -58,6 +59,7 @@ Feature: C function example command "delete_forward_entry"
       | SW 0x1 | -s 0x1 |
       | SW 0x2 | -s 0x2 |
 
+  @slow_process
   Scenario Outline: Delete 'RepeaterHub' only from Switch Manager's event forwarding entries of packet_in
     Given a file named "nw_dsl.conf" with:
       """
@@ -77,6 +79,7 @@ Feature: C function example command "delete_forward_entry"
       | 0x1    |
       | 0x2    |
 
+  @slow_process
   Scenario Outline: Delete 'RepeaterHub' only from Switch Daemon 0x1's event forwarding entries of packet_in
     Given a file named "nw_dsl.conf" with:
       """

--- a/features/switch_event/C-dump_forward_entries.feature
+++ b/features/switch_event/C-dump_forward_entries.feature
@@ -37,6 +37,7 @@ Feature: C function example command "dump_forward_entries"
         -t, --type={vendor,packet_in,port_status,state_notify} Specify event type.
       """
 
+  @slow_process
   Scenario Outline: Dump Switch Manager's event forwarding entries for each event type
     Given a file named "nw_dsl.conf" with:
       """
@@ -56,6 +57,7 @@ Feature: C function example command "dump_forward_entries"
       | port_status  |
       | state_notify |
 
+  @slow_process
   Scenario Outline: Dump Switch Daemon's event forwarding entries for each event type on each switch
     Given a file named "nw_dsl.conf" with:
       """

--- a/features/switch_event/C-set_forward_entries.feature
+++ b/features/switch_event/C-set_forward_entries.feature
@@ -38,6 +38,7 @@ Feature: C function example command "set_forward_entries"
         -t, --type={vendor,packet_in,port_status,state_notify} Specify event type.
       """
 
+  @slow_process
   Scenario Outline: Replace Switch Manager's event forwarding entries of packet_in to 'mirror' and 'filter'
     Given a file named "nw_dsl.conf" with:
       """
@@ -61,6 +62,7 @@ Feature: C function example command "set_forward_entries"
       | 0x1    |
       | 0x2    |
 
+  @slow_process
   Scenario Outline: Replace Switch Daemon 0x1's event forwarding entries of packet_in to 'mirror' and 'filter'
     Given a file named "nw_dsl.conf" with:
       """

--- a/features/switch_event/add_forward_entry.feature
+++ b/features/switch_event/add_forward_entry.feature
@@ -29,6 +29,7 @@ Feature: Ruby methods for adding switch event forwarding entry
   All the above methods take a result handler as Ruby block, but 
   can be omitted if checking is not necessary.
 
+  @slow_process
   Scenario Outline: add_forward_entry_to_all_switches event_type, trema_name
     Given a file named "nw_dsl.conf" with:
       """
@@ -78,6 +79,7 @@ Feature: Ruby methods for adding switch event forwarding entry
       | :port_status  | "new_controller", "AddEntryToAllTest" | "new_controller", "AddEntryToAllTest"                   |
       | :state_notify | "new_controller", "AddEntryToAllTest" | "new_controller", "AddEntryToAllTest", "switch_manager" |
 
+  @slow_process
   Scenario Outline: add_forward_entry_to_switch dpid, event_type, trema_name
     Given a file named "nw_dsl.conf" with:
       """
@@ -111,6 +113,7 @@ Feature: Ruby methods for adding switch event forwarding entry
       | :port_status  | "new_controller", "AddEntryToSwitchDaemonTest"                   |
       | :state_notify | "new_controller", "AddEntryToSwitchDaemonTest", "switch_manager" |
 
+  @slow_process
   Scenario Outline: add_forward_entry_to_switch_manager event_type, trema_name
     Given a file named "AddEntryToSwitchManagerTest.rb" with:
       """ruby

--- a/features/switch_event/delete_forward_entry.feature
+++ b/features/switch_event/delete_forward_entry.feature
@@ -29,6 +29,7 @@ Feature: Ruby methods for deleting switch event forwarding entry
   All the above methods take a result handler as Ruby block, but 
   they can be omitted if checking is not necessary.
 
+  @slow_process
   Scenario Outline: delete_forward_entry_from_all_switches event_type, trema_name
     Given a file named "nw_dsl.conf" with:
       """
@@ -78,6 +79,7 @@ Feature: Ruby methods for deleting switch event forwarding entry
       | :port_status  |                           |                   |
       | :state_notify |                           | "switch_manager"  |
 
+  @slow_process
   Scenario Outline: delete_forward_entry_from_switch dpid, event_type, trema_name
     Given a file named "nw_dsl.conf" with:
       """
@@ -111,6 +113,7 @@ Feature: Ruby methods for deleting switch event forwarding entry
       | :port_status  |                   |
       | :state_notify | "switch_manager"  |
 
+  @slow_process
   Scenario Outline: delete_forward_entry_from_switch_manager event_type, trema_name
     Given a file named "DeleteFromSwitchManagerTest.rb" with:
       """ruby

--- a/features/switch_event/dump_forward_entries.feature
+++ b/features/switch_event/dump_forward_entries.feature
@@ -22,6 +22,7 @@ Feature: Ruby methods for dumping switch event forwarding entry
   ----
   All the above methods take a result handler as Ruby block.
 
+  @slow_process
   Scenario Outline: dump_forward_entries_from_switch dpid, event_type
     Given a file named "nw_dsl.conf" with:
       """
@@ -56,6 +57,7 @@ Feature: Ruby methods for dumping switch event forwarding entry
       | :port_status  | "port_status"                            |
       | :state_notify | "DumpSwitchDaemonTest", "switch_manager" |
 
+  @slow_process
   Scenario Outline: dump_forward_entries_from_switch_manager event_type
     Given a file named "nw_dsl.conf" with:
       """

--- a/features/switch_event/set_forward_entries.feature
+++ b/features/switch_event/set_forward_entries.feature
@@ -26,6 +26,7 @@ Feature: Ruby methods for setting switch event forwarding entry
   All the above methods take a result handler as Ruby block, but 
   they can be omitted if checking is not necessary.
 
+  @slow_process
   Scenario Outline: set_forward_entries_to_switch dpid, event_type, trema_names
     Given a file named "nw_dsl.conf" with:
       """
@@ -59,6 +60,7 @@ Feature: Ruby methods for setting switch event forwarding entry
       | :port_status  | "SetEntriesToSwitchDaemonTest", "Another" |
       | :state_notify | "SetEntriesToSwitchDaemonTest", "Another" |
 
+  @slow_process
   Scenario Outline: set_forward_entries_to_switch_manager event_type, trema_names
     Given a file named "SetEntriesToSwitchManagerTest.rb" with:
       """ruby


### PR DESCRIPTION
Add @slow_process to potentially slow scenarios to avoid false positive test failures on switch event features.
