### PR TITLE
fix segfault on portless OFPT_FEATURES_REPLY

### DIFF
--- a/ruby/trema/features-reply.c
+++ b/ruby/trema/features-reply.c
@@ -305,14 +305,17 @@ handle_features_reply(
   rb_hash_aset( attributes, ID2SYM( rb_intern( "actions" ) ), UINT2NUM( actions ) );
   rb_hash_aset( attributes, ID2SYM( rb_intern( "ports" ) ), ports_from( ports ) );
 
-  list_element *tmp_ports = xmalloc( sizeof( list_element ) );
-  memcpy( tmp_ports, ports, sizeof( list_element ) );
   list_element *physical_ports = xmalloc( sizeof( list_element ) );
   create_list( &physical_ports );
-  iterate_list( tmp_ports, append_physical_port, &physical_ports );
+  if ( ports != NULL ) {
+    // use memcpy() to walk over the const qualifier
+    list_element *tmp_ports = xmalloc( sizeof( list_element ) );
+    memcpy( tmp_ports, ports, sizeof( list_element ) );
+    iterate_list( tmp_ports, append_physical_port, &physical_ports );
+    xfree( tmp_ports );
+  }
   rb_hash_aset( attributes, ID2SYM( rb_intern( "physical_ports" ) ), ports_from( physical_ports ) );
   xfree( physical_ports );
-  xfree( tmp_ports );
 
   VALUE features_reply = rb_funcall( cFeaturesReply, rb_intern( "new" ), 1, attributes );
   rb_funcall( ( VALUE ) controller, rb_intern( "features_reply" ), 2, ULL2NUM( datapath_id ), features_reply );


### PR DESCRIPTION
Only the bugfix is here, the unit tests were left intact. There is an existing test named `test_handle_features_reply_without_phy_port`, but I was not sure how and if it should be updated.
