### PR TITLE
Add :transaction_id as an option parameter of Controller#send_flow_mod_{add,delete,modify}

### DIFF
--- a/ruby/trema/controller.c
+++ b/ruby/trema/controller.c
@@ -211,7 +211,8 @@ controller_send_flow_mod( uint16_t command, int argc, VALUE *argv, VALUE self ) 
     VALUE opt_transaction_id = rb_hash_aref( options, ID2SYM( rb_intern( "transaction_id" ) ) );
     if ( opt_transaction_id != Qnil ) {
       transaction_id = ( uint32_t ) NUM2ULONG( opt_transaction_id );
-    } else {
+    }
+    else {
       transaction_id = get_transaction_id();
     }
 
@@ -223,7 +224,8 @@ controller_send_flow_mod( uint16_t command, int argc, VALUE *argv, VALUE self ) 
     VALUE opt_cookie = rb_hash_aref( options, ID2SYM( rb_intern( "cookie" ) ) );
     if ( opt_cookie != Qnil ) {
       cookie = NUM2ULL( opt_cookie );
-    } else {
+    }
+    else {
       cookie = get_cookie();
     }
 


### PR DESCRIPTION
Current Ruby Controller allows OpenFlow messages such as BarrierRequest to be sent with user supplied transaction_ids, but it is not possible to specify transaction_id when sending FlowMod messages using 
`Controller#send_flow_mod_{add,delete,modify}` methods.

This patch adds `:transaction_id` to the `options` hash to let user specify transaction_id 
when using `Controller#send_flow_mod_{add,delete,modify}` methods.
