### PR TITLE
fix protocol version negotiation

### DIFF
--- a/src/lib/openflow_message.c
+++ b/src/lib/openflow_message.c
@@ -1658,6 +1658,13 @@ append_action_vendor( openflow_actions *actions, const uint32_t vendor, const bu
   return ret;
 }
 
+// A valid remote version is one of the defined wire protocol numbers for a
+// HELLO message and strictly OpenFlow 1.0 for any other message.
+bool
+valid_message_version( const uint8_t type, const uint8_t version ) {
+  return type != OFPT_HELLO ? version == OFP_VERSION :
+    version >= OFP_VERSION && version <= 0x04; // 1.0~1.3
+}
 
 static int
 validate_header( const buffer *message, const uint8_t type,
@@ -1670,7 +1677,7 @@ validate_header( const buffer *message, const uint8_t type,
   }
 
   header = ( struct ofp_header * ) message->data;
-  if ( header->version != OFP_VERSION ) {
+  if ( ! valid_message_version( type, header->version ) ) {
     return ERROR_UNSUPPORTED_VERSION;
   }
   if ( header->type > OFPT_QUEUE_GET_CONFIG_REPLY ) {

--- a/src/lib/openflow_message.h
+++ b/src/lib/openflow_message.h
@@ -268,6 +268,7 @@ int validate_action_enqueue( const struct ofp_action_enqueue *action );
 int validate_action_vendor( const struct ofp_action_vendor_header *action );
 int validate_openflow_message( const buffer *message );
 bool valid_openflow_message( const buffer *message );
+bool valid_message_version( const uint8_t type, const uint8_t version );
 
 // Utility functions
 bool get_error_type_and_code( const uint8_t type, const int error_no,

--- a/src/switch_manager/secure_channel_receiver.c
+++ b/src/switch_manager/secure_channel_receiver.c
@@ -65,7 +65,7 @@ recv_from_secure_channel( struct switch_info *sw_info ) {
   size_t read_total = 0;
   while ( sw_info->fragment_buf->length >= sizeof( struct ofp_header ) ) {
     struct ofp_header *header = sw_info->fragment_buf->data;
-    if ( header->version != OFP_VERSION ) {
+    if ( ! valid_message_version( header->type, header->version ) ) {
       error( "Receive error: invalid version (version %d)", header->version );
       ofpmsg_send_error_msg( sw_info,
                              OFPET_BAD_REQUEST, OFPBRC_BAD_VERSION, sw_info->fragment_buf );


### PR DESCRIPTION
This fix was produced using a switch that supports OpenFlow versions 1.0 through 1.3. Please review.
