### PR TITLE
Add latest of each ruby version in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ script: "rake travis"
 
 rvm:
   - 1.8.7
+  - 1.9.3
+  - 2.0.0
 
 branches:
   only:


### PR DESCRIPTION
Since trema started supporting 1.9 and 2.0 series,  we might want travis CI to also run using ruby version other than 1.8.7.
Although Travis CI is pretty much useless for trema testing due to #287.
