### PR TITLE
Workaround for rb_block_given_p() return value change in Ruby 1.9 series...

### DIFF
--- a/features/switch_event/add_forward_entry.feature
+++ b/features/switch_event/add_forward_entry.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Ruby methods for adding switch event forwarding entry
   
   There are three Ruby methods provided for adding switch event forwarding entries:

--- a/features/switch_event/delete_forward_entry.feature
+++ b/features/switch_event/delete_forward_entry.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Ruby methods for deleting switch event forwarding entry
   
   There are three Ruby methods provided for deleting switch event forwarding entries.

--- a/features/switch_event/dump_forward_entries.feature
+++ b/features/switch_event/dump_forward_entries.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Ruby methods for dumping switch event forwarding entry
   
   There are two Ruby methods provided for dumping switch event forwarding entry.

--- a/features/switch_event/set_forward_entries.feature
+++ b/features/switch_event/set_forward_entries.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Ruby methods for setting switch event forwarding entry
   
   There are two Ruby methods provided for setting switch event forwarding entry.

--- a/ruby/trema/switch-event.c
+++ b/ruby/trema/switch-event.c
@@ -110,7 +110,7 @@ add_forward_entry_to_all_switches( VALUE self, VALUE type, VALUE service_name ) 
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = add_event_forward_entry_to_all_switches(
@@ -159,7 +159,7 @@ delete_forward_entry_from_all_switches( VALUE self, VALUE type,
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = delete_event_forward_entry_to_all_switches(
@@ -235,7 +235,7 @@ add_forward_entry_to_switch( VALUE self, VALUE dpid, VALUE type,
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = add_switch_event_forward_entry(
@@ -287,7 +287,7 @@ delete_forward_entry_from_switch( VALUE self, VALUE dpid, VALUE type,
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = delete_switch_event_forward_entry(
@@ -345,7 +345,7 @@ set_forward_entries_to_switch( VALUE self, VALUE dpid, VALUE type,
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = set_switch_event_forward_entries(
@@ -393,7 +393,7 @@ dump_forward_entries_from_switch( VALUE self, VALUE dpid, VALUE type ) {
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = dump_switch_event_forward_entries(
@@ -443,7 +443,7 @@ add_forward_entry_to_switch_manager( VALUE self, VALUE type,
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = add_switch_manager_event_forward_entry(
@@ -493,7 +493,7 @@ delete_forward_entry_from_switch_manager( VALUE self, VALUE type,
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = delete_switch_manager_event_forward_entry(
@@ -549,7 +549,7 @@ set_forward_entries_to_switch_manager( VALUE self, VALUE type,
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = set_switch_manager_event_forward_entries(
@@ -594,7 +594,7 @@ dump_forward_entries_from_switch_manager( VALUE self, VALUE type ) {
   callback_info *cb = xcalloc( 1, sizeof( callback_info ) );
   cb->self = self;
   cb->block = Qnil;
-  if ( rb_block_given_p() == Qtrue ) {
+  if ( rb_block_given_p() ) {
     cb->block = rb_block_proc();
   }
   bool succ = dump_switch_manager_event_forward_entries(


### PR DESCRIPTION
Fix for issue mentioned at trema/trema@be7f0725894a120c3c486bed3583ed4e3ee1980f

See: 
 http://transitive.info/2011/02/18/note-rb_block_given_p/

cruise.rb script passed on Ubuntu Server 12.04 LTS using following Ruby version installed using RVM.
- ruby-1.8.7-p374 [ x86_64 ]
- ruby-1.9.3-p448 [ x86_64 ]
- ruby-2.0.0-p247 [ x86_64 ]
