### PR TITLE
Use separate packet out for learning switch examples

### DIFF
--- a/src/examples/learning_switch/learning-switch.rb
+++ b/src/examples/learning_switch/learning-switch.rb
@@ -69,7 +69,9 @@ class LearningSwitch < Controller
   def packet_out datapath_id, message, port_no
     send_packet_out(
       datapath_id,
-      :packet_in => message,
+      :in_port => message.in_port,
+      :buffer_id => 0xffffffff,
+      :data => message.data,
       :actions => ActionOutput.new( :port => port_no )
     )
   end


### PR DESCRIPTION
Currently learning switch C example sends Flow Mod with valid buffer_id.
But the style is noted as dangerous in [1].
This patch separates Flow Mod and Packet Out.

And Ruby example sends Packet-Out after Flow Mod without data.
This patch solves the issue too.

[1] https://github.com/yasuhito/trema-book/blob/master/ja/openflow_spec.re
