### PR TITLE
cruise.rb runs only @critical tests to speed up Trema's test suite.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -940,9 +940,15 @@ end
 
 begin
   require "cucumber/rake/task"
+
   task :features => :build_trema
   Cucumber::Rake::Task.new( :features ) do | t |
-    t.cucumber_opts = "features --tags ~@wip"
+    t.cucumber_opts = "--tags @critical --tags ~@wip"
+  end
+
+  task 'features:all' => :build_trema
+  Cucumber::Rake::Task.new( 'features:all' ) do | t |
+    t.cucumber_opts = "--tags ~@wip"
   end
 rescue LoadError
   $stderr.puts $!.to_s

--- a/cruise.rb
+++ b/cruise.rb
@@ -313,18 +313,31 @@ def test message
 end
 
 
-def run_unit_test
+def run_unit_tests
   test "Running unit tests ..." do
     sh "bundle exec rake unittests"
+  end
+  measure_coverage
+end
+
+
+def run_rspec
+  test "Running rspec ..." do
     sh "bundle exec rake spec"
   end
   measure_coverage
 end
 
 
-def run_acceptance_test
+def run_ruby_acceptance_tests
   test "Running acceptance tests ..." do
     sh "bundle exec rake features"
+  end
+end
+
+def run_all_acceptance_tests
+  test "Running acceptance tests ..." do
+    sh "bundle exec rake features:all"
   end
 end
 
@@ -341,6 +354,10 @@ end
 
 $options.on( "-a", "--acceptance-test-only" ) do
   $acceptance_test_only = true
+end
+
+$options.on( "-A", "--all" ) do
+  $all = true
 end
 
 $options.separator ""
@@ -369,8 +386,17 @@ Blocker.start do
   $start_time = Time.now
   cd Trema.home do
     init_cruise
-    run_unit_test if not $acceptance_test_only
-    run_acceptance_test if not $unit_test_only
+    if not $acceptance_test_only
+      run_unit_tests if $all
+      run_rspec
+    end
+    if not $unit_test_only
+      if $all
+        run_all_acceptance_tests
+      else
+        run_ruby_acceptance_tests
+      end
+    end
     show_summary if not $acceptance_test_only
   end
 end

--- a/features/examples/dumper.feature
+++ b/features/examples/dumper.feature
@@ -16,7 +16,7 @@ Feature: "Dumper" sample application
       link "dumper", "host2"
       """
 
-  @slow_process @ruby
+  @slow_process @critical @ruby
   Scenario: Run "Dumper" Ruby example
     Given I run `trema run ../../src/examples/dumper/dumper.rb -c dumper.conf -d`
      And wait until "Dumper" is up

--- a/features/examples/hello_trema.feature
+++ b/features/examples/hello_trema.feature
@@ -11,7 +11,7 @@ Feature: "Hello Trema!" example
   Background:
     Given I cd to "../../src/examples/hello_trema/"
 
-  @slow_process @ruby
+  @slow_process @critical @ruby
   Scenario: Run the Ruby example
     When I run `trema run ./hello-trema.rb -c sample.conf` interactively
     Then the output should contain "Hello 0xabc!" within the timeout period

--- a/features/trema_commands/send_packets.feature
+++ b/features/trema_commands/send_packets.feature
@@ -18,7 +18,7 @@ Feature: send_packets command
       """
     And I run `trema run ../../src/examples/learning_switch/learning-switch.rb -c learning_switch.conf -d`
 
-  @slow_process
+  @slow_process @critical
   Scenario: Sending packets
     When I run `trema send_packets --source host1 --dest host2 --n_pkts=2`
      And I run `trema send_packets --source host2 --dest host1 --n_pkts=1`


### PR DESCRIPTION
To run all tests, do "cruise.rb --all".
