### PR TITLE
Send Packet-Out with data to prevent packet loss

### DIFF
--- a/src/examples/learning_switch/learning-switch.rb
+++ b/src/examples/learning_switch/learning-switch.rb
@@ -69,7 +69,9 @@ class LearningSwitch < Controller
   def packet_out datapath_id, message, port_no
     send_packet_out(
       datapath_id,
-      :packet_in => message,
+      :in_port => message.in_port,
+      :buffer_id => 0xffffffff,
+      :data => message.data,
       :actions => ActionOutput.new( :port => port_no )
     )
   end


### PR DESCRIPTION
Current code sends Packet-Out with buffer_id.
This works when the destination switch has cached the packet which has appropriate buffer_id.
But the packet can be lost.
So this patch modifies the code to send Packet-Out with data.
