### PR TITLE
quick hack of 'cruise.rb'

### DIFF
--- a/cruise.rb
+++ b/cruise.rb
@@ -397,7 +397,7 @@ Blocker.start do
         run_ruby_acceptance_tests
       end
     end
-    show_summary if not $acceptance_test_only
+    show_summary if not $acceptance_test_only and $all
   end
 end
 


### PR DESCRIPTION
Fixed an issue of ’cruise.rb’
-  './cruise.rb --all' does not work
-  './cruise.rb' displays 'coverage = 0.0%' and returns error status (255). 
