### PR TITLE
fix "rake unittests failed!" issue on centos/scientific linux 6.4

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -326,7 +326,7 @@ task "vendor:cmockery" => Trema.libcmockery_a
 file Trema.libcmockery_a do
   sh "tar xzf #{ Trema.vendor_cmockery }.tar.gz -C #{ Trema.vendor }"
   cd Trema.vendor_cmockery do
-    sh "./configure --prefix=#{ Trema.cmockery }"
+    sh "./configure --disable-shared --prefix=#{ Trema.cmockery }"
     sh "make install"
   end
 end
@@ -824,7 +824,7 @@ libtrema_unit_tests.keys.each do | each |
     task.sources = test_c_files( each ) + [ "unittests/lib/#{ each }.c" ]
     task.includes = [ Trema.include, Trema.openflow, File.dirname( Trema.cmockery_h ), "unittests" ]
     task.cflags = [ "-DUNIT_TESTING", "--coverage", CFLAGS ]
-    task.ldflags = "-DUNIT_TESTING -L#{ File.dirname Trema.libcmockery_a } --coverage --static"
+    task.ldflags = "-DUNIT_TESTING -L#{ File.dirname Trema.libcmockery_a } --coverage"
     task.library_dependencies = [
                                  "cmockery",
                                  "sqlite3",
@@ -871,7 +871,7 @@ $tests.each do | _each |
     task.sources = [ "unittests/lib/#{ each }.c", "unittests/cmockery_trema.c" ]
     task.includes = [ Trema.include, Trema.openflow, File.dirname( Trema.cmockery_h ), "unittests" ]
     task.cflags = [ "--coverage", CFLAGS ]
-    task.ldflags = "-L#{ File.dirname Trema.libcmockery_a } -Lobjects/unittests --coverage --static"
+    task.ldflags = "-L#{ File.dirname Trema.libcmockery_a } -Lobjects/unittests --coverage"
     task.library_dependencies = [
                                  "trema",
                                  "cmockery",


### PR DESCRIPTION
- disable shared library of cmockery
- remove '-static' option of ld

```
    (test in centos and scientific linux 6.4 w/ ruby1.9.3)
    $ sudo -s
    # yum install http://rdo.fedorapeople.org/openstack/openstack-grizzly/rdo-release-grizzly.rpm
    # yum update
    # yum install gcc make git ruby193-ruby ruby193-ruby-devel libpcap-devel sqlite-devel glib2-devel
    # echo /opt/rh/ruby193/root/usr/lib64 > /etc/ld.so.conf.d/ruby193-x86_64.conf
    # ldconfig
    # /opt/rh/ruby193/root/usr/bin/gem install bundler
    # exit
    $ export PATH=$PATH:/opt/rh/ruby193/root/usr/bin:/opt/rh/ruby193/root/usr/local/bin
    $ mkdir work
    $ cd work
    $ git clone https://github.com/trema/trema.git
    $ cd trema
    $ bundle config --local path vendor/bundle
    $ ./cruise.rb --all
    ...
    /usr/bin/ld: cannot find -lsqlite3
    ...
    'bundle exec rake unittests' failed!
    ...
    (centos/scientific linux does not provide a static library of sqlite3)
```
