### PR TITLE
Add trema run -p (--port) option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## develop (unreleased)
 
 ### Changes
+* [#384](https://github.com/trema/trema/pull/384): Add trema run --port (-p) option to override the default OpenFlow channel listen port.
 * [#383](https://github.com/trema/trema/pull/383): Use the IANA-assigned port 6653 by default.

--- a/bin/trema
+++ b/bin/trema
@@ -33,6 +33,9 @@ module Trema
       c.desc 'Use OpenFlow1.3'
       c.switch :openflow13, default_value: false
 
+      c.desc 'Overrides the default openflow channel port'
+      c.flag [:p, :port]
+
       c.desc 'Location to put pid files'
       c.flag [:P, :pid_dir], default_value: Trema::DEFAULT_PID_DIR
       c.desc 'Location to put log files'

--- a/features/open_flow13.feature
+++ b/features/open_flow13.feature
@@ -6,7 +6,7 @@ Feature: OpenFlow1.3
       | TREMA_PID_DIR    | .     |
       | TREMA_SOCKET_DIR | .     |
 
-  @sudo @announce
+  @sudo
   Scenario: trema run with --openflow13 option
     Given a file named "null_controller.rb" with:
       """

--- a/features/trema_run.feature
+++ b/features/trema_run.feature
@@ -1,0 +1,47 @@
+Feature: trema run command
+  Background:
+    Given I set the environment variables to:
+      | variable         | value |
+      | TREMA_LOG_DIR    | .     |
+      | TREMA_PID_DIR    | .     |
+      | TREMA_SOCKET_DIR | .     |
+
+  @sudo
+  Scenario: the default port
+    Given a file named "switch_ready.rb" with:
+      """
+      class SwitchReady < Trema::Controller
+        def switch_ready(dpid)
+          logger.info format('Hello %s!', dpid.to_hex)
+        end
+      end
+      """
+    And a file named "trema.conf" with:
+      """
+      vswitch { datapath_id 0xabc }
+      """
+    When I successfully run `trema -v run switch_ready.rb -c trema.conf -d`
+    And I run `sleep 5`
+    Then the file "SwitchReady.log" should contain "Hello 0xabc!"
+
+  @sudo
+  Scenario: -p option
+    Given a file named "switch_ready.rb" with:
+      """
+      class SwitchReady < Trema::Controller
+        def switch_ready(dpid)
+          logger.info format('Hello %s!', dpid.to_hex)
+        end
+      end
+      """
+    And a file named "trema.conf" with:
+      """
+      vswitch {
+        datapath_id 0xabc
+        port 1234
+      }
+      """
+    When I successfully run `trema -v run -p 1234 switch_ready.rb -c trema.conf -d`
+    And I run `sleep 5`
+    Then the file "SwitchReady.log" should contain "Hello 0xabc!"
+

--- a/lib/trema/command.rb
+++ b/lib/trema/command.rb
@@ -24,7 +24,8 @@ module Trema
         options[:verbose] ? ::Logger::DEBUG : ::Logger::INFO
       $LOAD_PATH.unshift File.expand_path(File.dirname(@args.first))
       load @args.first
-      @controller = Controller.create
+      port_number = (options[:port] || Controller::DEFAULT_TCP_PORT).to_i
+      @controller = Controller.create(port_number)
 
       trap_signals
       create_pid_file

--- a/lib/trema/controller.rb
+++ b/lib/trema/controller.rb
@@ -104,12 +104,13 @@ module Trema
     # rubocop:enable TrivialAccessors
 
     # @private
-    def self.create
-      @controller_klass.new
+    def self.create(port_number = DEFAULT_TCP_PORT)
+      @controller_klass.new(port_number)
     end
 
     # @private
-    def initialize
+    def initialize(port_number = DEFAULT_TCP_PORT)
+      @port_number = port_number
       @threads = []
       @logger = Logger.new(name)
       @logger.level = Controller.logging_level
@@ -124,7 +125,7 @@ module Trema
         File.expand_path(File.join(Phut.socket_dir, "#{name}.ctl"))
       @drb = DRb::DRbServer.new 'drbunix:' + drb_socket_file, self
       maybe_send_handler :start, args
-      socket = TCPServer.open('<any>', DEFAULT_TCP_PORT)
+      socket = TCPServer.open('<any>', @port_number)
       start_timers
       loop { start_switch_thread(socket.accept) }
     end


### PR DESCRIPTION
Adds trema run --port (-p) option to override the default OpenFlow channel listen port.
refs #334 