### PR TITLE
Allow packet_in, etc during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## develop (unreleased)
-
+* [#392](https://github.com/trema/trema/pull/392): Allow packet_in, etc during startup
 
 ## 0.4.8 (6/29/2015)
 ### Changes


### PR DESCRIPTION
There may be async messages from switch before trema controller becomes ready state.
