### PR TITLE
Add SSL support for socket between controller and switch

### DIFF
--- a/bin/trema
+++ b/bin/trema
@@ -45,13 +45,6 @@ module Trema
       c.desc 'Location to put socket files'
       c.flag [:S, :socket_dir], default_value: Trema::DEFAULT_SOCKET_DIR
 
-      c.desc 'SSL private key file path'
-      c.flag [:ctl_privkey]
-      c.desc 'SSL certification file path'
-      c.flag [:ctl_cert]
-      c.desc 'SSL CA file path'
-      c.flag [:ca_certs]
-
       c.action do |global_options, options, args|
         Phut.pid_dir = options[:pid_dir]
         Phut.log_dir = options[:log_dir]

--- a/bin/trema
+++ b/bin/trema
@@ -45,6 +45,13 @@ module Trema
       c.desc 'Location to put socket files'
       c.flag [:S, :socket_dir], default_value: Trema::DEFAULT_SOCKET_DIR
 
+      c.desc 'SSL private key file path'
+      c.flag [:ctl_privkey]
+      c.desc 'SSL certification file path'
+      c.flag [:ctl_cert]
+      c.desc 'SSL CA file path'
+      c.flag [:ca_certs]
+
       c.action do |global_options, options, args|
         Phut.pid_dir = options[:pid_dir]
         Phut.log_dir = options[:log_dir]

--- a/lib/trema/command.rb
+++ b/lib/trema/command.rb
@@ -35,9 +35,6 @@ module Trema
         raise(InvalidLoggingLevel,
               "Invalid logging level: #{options[:logging_level]}")
       end
-      Controller.ctl_privkey = options[:ctl_privkey]
-      Controller.ctl_cert = options[:ctl_cert]
-      Controller.ca_certs = options[:ca_certs]
 
       $LOAD_PATH.unshift File.expand_path(File.dirname(@args.first))
       load @args.first

--- a/lib/trema/command.rb
+++ b/lib/trema/command.rb
@@ -35,6 +35,9 @@ module Trema
         raise(InvalidLoggingLevel,
               "Invalid logging level: #{options[:logging_level]}")
       end
+      Controller.ctl_privkey = options[:ctl_privkey]
+      Controller.ctl_cert = options[:ctl_cert]
+      Controller.ca_certs = options[:ca_certs]
 
       $LOAD_PATH.unshift File.expand_path(File.dirname(@args.first))
       load @args.first

--- a/lib/trema/controller.rb
+++ b/lib/trema/controller.rb
@@ -5,7 +5,6 @@ require 'socket'
 require 'trema/command'
 require 'trema/logger'
 require 'trema/monkey_patch/integer'
-require 'openssl'
 
 module Trema
   class NoControllerDefined < StandardError; end
@@ -111,13 +110,9 @@ module Trema
 
     class << self
       attr_accessor :logging_level
-      attr_accessor :ctl_privkey
-      attr_accessor :ctl_cert
-      attr_accessor :ca_certs
     end
 
     include Pio
-    include OpenSSL
 
     SWITCH = {}
     DEFAULT_TCP_PORT = 6653
@@ -164,21 +159,7 @@ module Trema
         File.expand_path(File.join(Phut.socket_dir, "#{name}.ctl"))
       @drb = DRb::DRbServer.new 'drbunix:' + drb_socket_file, self
       maybe_send_handler :start, args
-
-      if Controller.ctl_privkey == nil || Controller.ctl_cert == nil ||
-         Controller.ca_certs == nil
-        socket = TCPServer.open('<any>', @port_number)
-        logger.debug "TCP socket"
-      else
-        ctx = SSL::SSLContext.new(:TLSv1_server)
-        ctx.cert = X509::Certificate.new(File.read(Controller.ctl_cert))
-        ctx.key = PKey::RSA.new(File.read(Controller.ctl_privkey))
-        ctx.ca_file = Controller.ca_certs
-        socket = SSL::SSLServer.new(TCPServer.open('<any>', @port_number), ctx)
-        logger.debug "SSL socket: ctl_privkey=#{Controller.ctl_privkey}," +
-          "ctl_cert=#{Controller.ctl_cert},ca_certs=#{Controller.ca_certs}"
-      end
-
+      socket = TCPServer.open('<any>', @port_number)
       start_timers
       loop { start_switch_thread(socket.accept) }
     end

--- a/lib/trema/controller.rb
+++ b/lib/trema/controller.rb
@@ -5,6 +5,7 @@ require 'socket'
 require 'trema/command'
 require 'trema/logger'
 require 'trema/monkey_patch/integer'
+require 'openssl'
 
 module Trema
   class NoControllerDefined < StandardError; end
@@ -110,9 +111,13 @@ module Trema
 
     class << self
       attr_accessor :logging_level
+      attr_accessor :ctl_privkey
+      attr_accessor :ctl_cert
+      attr_accessor :ca_certs
     end
 
     include Pio
+    include OpenSSL
 
     SWITCH = {}
     DEFAULT_TCP_PORT = 6653
@@ -159,7 +164,21 @@ module Trema
         File.expand_path(File.join(Phut.socket_dir, "#{name}.ctl"))
       @drb = DRb::DRbServer.new 'drbunix:' + drb_socket_file, self
       maybe_send_handler :start, args
-      socket = TCPServer.open('<any>', @port_number)
+
+      if Controller.ctl_privkey.nil? || Controller.ctl_cert.nil? ||
+         Controller.ca_certs.nil?
+        socket = TCPServer.open('<any>', @port_number)
+        logger.debug 'TCP socket'
+      else
+        ctx = SSL::SSLContext.new(:TLSv1_server)
+        ctx.cert = X509::Certificate.new(File.read(Controller.ctl_cert))
+        ctx.key = PKey::RSA.new(File.read(Controller.ctl_privkey))
+        ctx.ca_file = Controller.ca_certs
+        socket = SSL::SSLServer.new(TCPServer.open('<any>', @port_number), ctx)
+        logger.debug "SSL socket: ctl_privkey=#{Controller.ctl_privkey}," \
+          "ctl_cert=#{Controller.ctl_cert},ca_certs=#{Controller.ca_certs}"
+      end
+
       start_timers
       loop { start_switch_thread(socket.accept) }
     end


### PR DESCRIPTION
--- How to use ---
[create certificates with Open vSwitch]
This command will create
	$ sudo ovs-pki init
Controller CA cert and
	/var/lib/openvswitch/pki/controllerca/cacert.pem
Switch CA cert.
	/var/lib/openvswitch/pki/switchca/cacert.pem

This command will create certificates for the Controller ./ctl-cert.pem and
./ctl-privkey.pem.
$ sudo ovs-pki req+sign ctl controller

This command will create certificates for the Switch ./sc-cert.pem and
./sc-privkey.pem.
$ sudo ovs-pki req+sign sc switch

[Configure Open vSwitch]
Configure Open vSwitch by this command.
$ sudo ovs-vsctl set-ssl <path to sc-privkey.pem> <path to sc-cert.pem> \
<path to Controller CA cert>
$ sudo ovs-vsctl set-controller br0 ssl:<hostname>:<portno>

[Configure trema]
Copy the ctl-cert.pem, ctl-privkey.pem and Switch CA cert to PC running trema.

Run trema by this command.
$ bundle exec ruby ./bin/trema -v run <path to controller file> \
--ctl_privkey=<path to ctl-privkey.pem> --ctl_cert=<path to ctl-cert.pem> \
--ca_certs=<path to Switch CA cert>

------------------
The new trema argument is base on Ryu SSL argument.
$ ryu-manager --ctl-privkey <path to ctl-privkey.pem> \
--ctl-cert <path to ctl-cert.pem> --ca-certs <path to Switch CA cert>

These commands are tested on this environment.
trema
	Ubuntu: 15.04 x64
switch
	Ubuntu: 14.04 x64
	Open vSwitch: 2.0.2

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>