### PR TITLE
Fix bundler dependency

### DIFF
--- a/trema.gemspec
+++ b/trema.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.test_files = `git ls-files -- {spec,features}/*`.split("\n")
 
-  gem.add_dependency 'bundler', '~> 1.11.2'
+  gem.add_dependency 'bundler', '>= 1.11.2', '< 2.0'
   gem.add_dependency 'gli', '~> 2.13.4'
   gem.add_dependency 'phut', '~> 0.7.7'
   gem.add_dependency 'pio', '~> 0.30.0'


### PR DESCRIPTION
Travis CI fails because trema depends on `~> 1.11.2` but on the version of bundler on Travis CI is `1.12.5`.

To avoid Travis CI failures of bundler dependency, I have changed bundler dependency.

As same as [rails](https://github.com/rails/rails/blob/master/rails.gemspec#L31).
